### PR TITLE
Dockerize dev setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# Structured Content 2022
+
+## Development
+
+For manual setup instructions, see the individual web/ and studio/ READMEs.
+
+Alternatively, you can use Docker and docker-compose. (The setup is tested with
+Docker version 20.10.12 and docker-compose version 1.25.3.)
+
+Starting both studio and web:
+
+```
+docker-compose up
+```
+
+The Studio is available on http://localhost:3333 while the app is available on
+http://localhost:3000.
+
+If you only want to start one of the services, you can use `docker-compose up
+studio` or `docker-compose up web` respectively.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '3.7'
+services:
+  studio:
+    build:
+      dockerfile: ./studio/Dockerfile
+      context: .
+    ports:
+      - 3333:3333
+    volumes:
+      - ./studio:/app
+
+  web:
+    build:
+      dockerfile: ./web/Dockerfile
+      context: .
+    ports:
+      - 3000:3000
+    volumes:
+      - ./web:/app

--- a/studio/Dockerfile
+++ b/studio/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:14
+
+RUN mkdir /app
+ADD . /app
+
+WORKDIR /app
+RUN yarn
+
+EXPOSE 3333
+
+CMD ["yarn", "sanity", "start", "--host=0.0.0.0"]

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:14
+
+RUN mkdir /app
+ADD . /app
+
+WORKDIR /app
+RUN yarn
+
+EXPOSE 3000
+
+CMD ["yarn", "dev"]


### PR DESCRIPTION
Adds a basic `docker-compose`-based setup that can be used for local development.

Testing this PR: See the new README.md file