### PR TITLE
Enable PostCSS processing of custom CSS media and properties

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -27,6 +27,8 @@
     "eslint": "8.6.0",
     "eslint-config-next": "12.0.8",
     "postcss": "^8.4.5",
+    "postcss-custom-media": "^8.0.0",
+    "postcss-custom-properties": "^12.1.4",
     "prettier": "^2.5.1",
     "tailwindcss": "^3.0.14",
     "typescript": "^4.5.5"

--- a/web/postcss.config.js
+++ b/web/postcss.config.js
@@ -2,5 +2,17 @@ module.exports = {
   plugins: {
     tailwindcss: {},
     autoprefixer: {},
+    'postcss-custom-media': {
+      preserve: false,
+      importFrom: [
+        './styles/media.css',
+      ],
+    },
+    'postcss-custom-properties': {
+      preserve: false,
+      importFrom: [
+        './styles/variables.css',
+      ],
+    },
   },
 };

--- a/web/styles/media.css
+++ b/web/styles/media.css
@@ -1,0 +1,2 @@
+/* Temporary breakpoint, actual ones TBD */
+@custom-media --large-up (min-width: 900px);

--- a/web/styles/variables.css
+++ b/web/styles/variables.css
@@ -1,0 +1,15 @@
+:root {
+  --color-brand-black: #000000;
+  --color-brand-orange: #ffba00;
+  --color-brand-white: #ffffff;
+  --color-brand-yellow: #fff17e;
+  --color-brand-yellow-light: #fff8e4;
+  --color-ui-gray-300: #deddd9;
+  --color-ui-gray-100: #f1f0eb;
+  --grid-gutter: 40px;
+  --grid-half-gutter: 20px;
+  --grid-width: 1440px;
+  --spacing-small: 40px;
+  --spacing-medium: 64px;
+  --spacing-large: 128px;
+}

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -2136,6 +2136,18 @@ picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.3:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
+postcss-custom-media@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-custom-media/-/postcss-custom-media-8.0.0.tgz#1be6aff8be7dc9bf1fe014bde3b71b92bb4552f1"
+  integrity sha512-FvO2GzMUaTN0t1fBULDeIvxr5IvbDXcIatt6pnJghc736nqNgsGao5NT+5+WVLAQiTt6Cb3YUms0jiPaXhL//g==
+
+postcss-custom-properties@^12.1.4:
+  version "12.1.4"
+  resolved "https://registry.yarnpkg.com/postcss-custom-properties/-/postcss-custom-properties-12.1.4.tgz#e3d8a8000f28094453b836dff5132385f2862285"
+  integrity sha512-i6AytuTCoDLJkWN/MtAIGriJz3j7UX6bV7Z5t+KgFz+dwZS15/mlTJY1S0kRizlk6ba0V8u8hN50Fz5Nm7tdZw==
+  dependencies:
+    postcss-value-parser "^4.2.0"
+
 postcss-js@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/postcss-js/-/postcss-js-4.0.0.tgz#31db79889531b80dc7bc9b0ad283e418dce0ac00"


### PR DESCRIPTION
##Summary

This PR intends to enable PostCSS processing of `@custom-media` and CSS custom properties (defined on `:root`).

Could optionally drop the latter, since we have confirmation that IE11 can be ignored.

## Testing this PR

1. `docker-compose up --build web`
2. Add a CSS rule somewhere that uses a custom media query and/or custom property. E.g. in web/components/Heading/Heading.module.css, add the line `@media (--large-up) { .heading { color: var(--color-brand-orange) } }`
3. `docker-compose exec web bash` in a separate terminal window, and `yarn run build`
4. Verify that the rule from step 2 was transformed so as to no longer include any `--` parts, e.g. `grep -or 'Heading_heading.[^}]*}' .next/static/css/` and `grep -or '@media.[^)]*)' .next/static/css/`