### PR TITLE
Implement components for new Section types in Page documents

### DIFF
--- a/web/components/Heading/Heading.module.css
+++ b/web/components/Heading/Heading.module.css
@@ -1,6 +1,7 @@
 .heading {
   font-weight: 700;
   line-height: 1.2;
+  margin: 0;
 }
 
 .h1 {

--- a/web/components/TextBlock/Block.tsx
+++ b/web/components/TextBlock/Block.tsx
@@ -1,0 +1,22 @@
+import { RichText } from './RichText';
+import { Person } from './Person';
+import { Venue } from './Venue';
+
+export const Block = ({ value }) =>
+  value.children.map((child, index) => {
+    if (!child._key && child._type) {
+      switch (child._type) {
+        case 'richText':
+          return <RichText value={child} />;
+        case 'person':
+          return <Person value={child} />;
+        case 'venue':
+          return <Venue value={child} />;
+        default:
+          console.log(`Unknown Block child type: "${child._type}"`);
+          return null;
+      }
+    }
+
+    return <span key={index}>{child.text}</span>;
+  });

--- a/web/components/TextBlock/Person.tsx
+++ b/web/components/TextBlock/Person.tsx
@@ -1,0 +1,8 @@
+import Link from 'next/link';
+import { getEntityPath } from '../../util/entityPaths';
+
+export const Person = ({ value: speaker }) => (
+  <Link href={getEntityPath(speaker)}>
+    <a>{speaker.name}</a>
+  </Link>
+);

--- a/web/components/TextBlock/QuestionAndAnswerCollection.tsx
+++ b/web/components/TextBlock/QuestionAndAnswerCollection.tsx
@@ -1,0 +1,18 @@
+import Heading from '../Heading';
+import { Block } from './Block';
+
+export const QuestionAndAnswerCollection = ({
+  value: { questions, title },
+}) => (
+  <>
+    <Heading type="h2">{title}</Heading>
+    {questions.map(({ _key, question, answer }) => (
+      <div key={_key}>
+        <Heading type="h3">{question}</Heading>
+        {answer.map((value) => (
+          <Block key={value._key} value={value} />
+        ))}
+      </div>
+    ))}
+  </>
+);

--- a/web/components/TextBlock/RichText.tsx
+++ b/web/components/TextBlock/RichText.tsx
@@ -1,0 +1,11 @@
+import Paragraph from '../Paragraph';
+
+export const RichText = ({ value }) => (
+  <>
+    {value.content
+      .reduce((acc, content) => [...acc, ...content.children], [])
+      .map((children) => (
+        <Paragraph key={children._key}>{children.text}</Paragraph>
+      ))}
+  </>
+);

--- a/web/components/TextBlock/SharedSections.tsx
+++ b/web/components/TextBlock/SharedSections.tsx
@@ -1,0 +1,40 @@
+import Image from 'next/image';
+import { imageUrlFor } from '../../lib/sanity';
+import Heading from '../Heading';
+
+const MailchimpSection = ({ value: { buttonText, id, title } }) => (
+  <form>
+    <label htmlFor={id}>{title}</label>
+    <br />
+    <input type="text" id={id} />
+    <button>{buttonText}</button>
+  </form>
+);
+
+const Figure = ({ value: { alt, asset } }) => (
+  <Image
+    src={imageUrlFor(asset).size(200, 200).url()}
+    width={200}
+    height={200}
+    alt={alt}
+  />
+);
+
+export const SharedSections = ({ value: { name, sections } }) => (
+  <>
+    <Heading type="h2">{name}</Heading>
+    {sections.map((section) => {
+      switch (section._type) {
+        case 'mailchimp':
+          return <MailchimpSection key={section._key} value={section} />;
+        case 'figure':
+          return <Figure key={section._key} value={section} />;
+        default:
+          console.log(
+            `Unrecognized SharedSections section type '${section._type}'`
+          );
+          return null;
+      }
+    })}
+  </>
+);

--- a/web/components/TextBlock/TextAndImage.tsx
+++ b/web/components/TextBlock/TextAndImage.tsx
@@ -1,0 +1,22 @@
+import Image from 'next/image';
+import { imageUrlFor } from '../../lib/sanity';
+import Heading from '../Heading';
+import { Block } from './Block';
+
+export const TextAndImage = ({ value: { image, tagline, text, title } }) => (
+  <>
+    <Heading type="h2">{title}</Heading>
+    <Heading type="h3">{tagline}</Heading>
+    {text.map((value) => (
+      <Block key={value._key} value={value} />
+    ))}
+    <div>
+      <Image
+        src={imageUrlFor(image).size(200, 200).url()}
+        width={200}
+        height={200}
+        alt=""
+      />
+    </div>
+  </>
+);

--- a/web/components/TextBlock/TextBlock.tsx
+++ b/web/components/TextBlock/TextBlock.tsx
@@ -3,52 +3,23 @@ import { PortableText, PortableTextComponents } from '@portabletext/react';
 import { PortableTextBlock } from '@portabletext/types';
 import { RichTextSection } from '../../types/RichTextSection';
 import { getEntityPath } from '../../util/entityPaths';
-import Paragraph from '../Paragraph';
-
-const RichText = ({ value }) => (
-  <>
-    {value.content
-      .reduce((acc, content) => [...acc, ...content.children], [])
-      .map((children) => (
-        <Paragraph key={children._key}>{children.text}</Paragraph>
-      ))}
-  </>
-);
-
-const Person = ({ value: speaker }) => (
-  <Link href={getEntityPath(speaker)}>
-    <a>{speaker.name}</a>
-  </Link>
-);
-
-const Venue = ({ value: venue }) => (
-  <Link href={getEntityPath(venue)}>
-    <a>{venue.title}</a>
-  </Link>
-);
+import { SharedSections } from './SharedSections';
+import { Person } from './Person';
+import { RichText } from './RichText';
+import { Block } from './Block';
+import { Venue } from './Venue';
+import { QuestionAndAnswerCollection } from './QuestionAndAnswerCollection';
+import { TextAndImage } from './TextAndImage';
 
 const components: Partial<PortableTextComponents> = {
   types: {
     richText: RichText,
     person: Person,
     venue: Venue,
-    block: ({ value }) =>
-      value.children.map((child, index) => {
-        if (!child._key && child._type) {
-          switch (child._type) {
-            case 'richText':
-              return <RichText value={child} />;
-            case 'person':
-              return <Person value={child} />;
-            case 'venue':
-              return <Venue value={child} />;
-            default:
-              return null;
-          }
-        }
-
-        return <span key={index}>{child.text}</span>;
-      }),
+    questionAndAnswerCollection: QuestionAndAnswerCollection,
+    block: Block,
+    textAndImage: TextAndImage,
+    sharedSections: SharedSections,
   },
   marks: {
     bold: ({ children }) => <strong>{children}</strong>,

--- a/web/components/TextBlock/Venue.tsx
+++ b/web/components/TextBlock/Venue.tsx
@@ -1,0 +1,8 @@
+import Link from 'next/link';
+import { getEntityPath } from '../../util/entityPaths';
+
+export const Venue = ({ value: venue }) => (
+  <Link href={getEntityPath(venue)}>
+    <a>{venue.title}</a>
+  </Link>
+);

--- a/web/pages/[[...slug]].tsx
+++ b/web/pages/[[...slug]].tsx
@@ -13,7 +13,10 @@ const QUERY = groq`
       ...,
       page-> {
         name,
-        sections
+        sections[] {
+          _type == 'reference' => @->,
+          _type != 'reference' => @,
+        }
       }
     }
   }`;


### PR DESCRIPTION
# Implement components for new Section types in Page documents

## Intent

@kmelve added some [new section types](http://localhost:3333/desk/route;188f7c30-b8c4-4c46-9917-33722517f9ce;611e0d92-2dce-4273-ba87-aacf75cb3b57%2Ctype%3Dpage%2CparentRefPath%3Dpage), as described in his [latest Loom](https://www.loom.com/share/c29722ad4fdd45dc9aa9ea6b0a5e3ebd). This PR implements basic, unstyled support for rendering these.

## Description

![image](https://user-images.githubusercontent.com/6001131/154120978-938d37bc-d9cf-4972-8c54-476fac79af76.png)

This PR implements basic support for the section types depicted above. At this stage, the goal is merely to get these sections to render -- no styling has been applied, so expect the output to be less-than-pretty.

## Testing this PR

1. Start the application (`docker-compose up` or run `npm run dev` in both _/web_ and _/studio_ directories)
2. Go to http://localhost:3000/test and verify that each of the _Sections_ in the [_Test route_](http://localhost:3333/desk/route;188f7c30-b8c4-4c46-9917-33722517f9ce;611e0d92-2dce-4273-ba87-aacf75cb3b57%2Ctype%3Dpage%2CparentRefPath%3Dpage) document render, and that no warnings or errors are printed in the console

## RFC

@kmelve:
- Are these all the section types we plan to support?
- I'm assuming that Sanity already has a Mailchimp account. Can you share the Mailchimp details with me, or otherwise provide the required info such that a working `<Mailchimp />` component can be implemented?