### PR TITLE
Consistent date range formatting for /home

### DIFF
--- a/web/components/ConferenceHeader/ConferenceHeader.tsx
+++ b/web/components/ConferenceHeader/ConferenceHeader.tsx
@@ -1,6 +1,6 @@
 import logo from '../../images/logo.svg';
 import styles from './ConferenceHeader.module.css';
-import DateRange from "../DateRange";
+import DateRange from '../DateRange';
 
 interface ConferenceHeaderProps {
   name?: string;

--- a/web/components/ConferenceHeader/ConferenceHeader.tsx
+++ b/web/components/ConferenceHeader/ConferenceHeader.tsx
@@ -1,6 +1,6 @@
-import { formatDateWithTime } from '../../util/date';
 import logo from '../../images/logo.svg';
 import styles from './ConferenceHeader.module.css';
+import DateRange from "../DateRange";
 
 interface ConferenceHeaderProps {
   name?: string;
@@ -29,13 +29,7 @@ export const ConferenceHeader = ({
       </h1>
       <div className={styles.summary}>
         <p>
-          {startDate && (
-            <time dateTime={startDate}>{formatDateWithTime(startDate)}</time>
-          )}
-          –
-          {endDate && (
-            <time dateTime={endDate}>{formatDateWithTime(endDate)}</time>
-          )}
+          <DateRange startDate={startDate} endDate={endDate} />
         </p>
         <p>{description}</p>
       </div>

--- a/web/components/DateRange/DateRange.tsx
+++ b/web/components/DateRange/DateRange.tsx
@@ -1,0 +1,19 @@
+import { formatDateRange } from "../../util/date";
+
+interface DateRangeProps {
+  startDate: string;
+  endDate: string;
+}
+
+export const DateRange = ({ startDate, endDate }: DateRangeProps) => {
+  if (!startDate || !endDate) {
+    return null;
+  }
+
+  const { start, end } = formatDateRange(startDate, endDate);
+  return (
+    <>
+      <time dateTime={start}>{start.trim()}</time>–<time dateTime={end}>{end.trim()}</time>
+    </>
+  )
+}

--- a/web/components/DateRange/DateRange.tsx
+++ b/web/components/DateRange/DateRange.tsx
@@ -1,4 +1,4 @@
-import { formatDateRange } from "../../util/date";
+import { formatDateRange } from '../../util/date';
 
 interface DateRangeProps {
   startDate: string;
@@ -13,7 +13,8 @@ export const DateRange = ({ startDate, endDate }: DateRangeProps) => {
   const { start, end } = formatDateRange(startDate, endDate);
   return (
     <>
-      <time dateTime={start}>{start.trim()}</time>–<time dateTime={end}>{end.trim()}</time>
+      <time dateTime={start}>{start.trim()}</time>–
+      <time dateTime={end}>{end.trim()}</time>
     </>
-  )
-}
+  );
+};

--- a/web/components/DateRange/index.ts
+++ b/web/components/DateRange/index.ts
@@ -1,1 +1,1 @@
-export { DateRange as default } from "./DateRange";
+export { DateRange as default } from './DateRange';

--- a/web/components/DateRange/index.ts
+++ b/web/components/DateRange/index.ts
@@ -1,0 +1,1 @@
+export { DateRange as default } from "./DateRange";

--- a/web/util/date.ts
+++ b/web/util/date.ts
@@ -1,4 +1,30 @@
 import { format } from 'date-fns';
 
 export const formatDateWithTime = (date: string) =>
-  format(new Date(date), 'MMMM d, yyyy hh:mm');
+  format(new Date(date), 'MMMM d, yyyy');
+
+const monthNames = [
+  "January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"
+];
+
+const utcDate = (date: string) => {
+  const d = new Date(date);
+  return {
+    day: d.getUTCDate(),
+    month: d.getUTCMonth(),
+    year: d.getUTCFullYear(),
+  }
+}
+
+export const formatDateRange = (date1: string, date2: string) => {
+  const d1 = utcDate(date1);
+  const d2 = utcDate(date2);
+
+  const y1 = Math.abs(d2.year - d1.year) > 0 ? `, ${d1.year}` : ''
+  const m2 = Math.abs(d2.month - d1.month) > 0 ? ` ${monthNames[d2.month]} ` : ''
+
+  return {
+    start: `${monthNames[d1.month]} ${d1.day}${y1}`,
+    end: `${m2}${d2.day}, ${d2.year}`,
+  }
+};

--- a/web/util/date.ts
+++ b/web/util/date.ts
@@ -4,7 +4,18 @@ export const formatDateWithTime = (date: string) =>
   format(new Date(date), 'MMMM d, yyyy');
 
 const monthNames = [
-  "January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December',
 ];
 
 const utcDate = (date: string) => {
@@ -13,18 +24,19 @@ const utcDate = (date: string) => {
     day: d.getUTCDate(),
     month: d.getUTCMonth(),
     year: d.getUTCFullYear(),
-  }
-}
+  };
+};
 
 export const formatDateRange = (date1: string, date2: string) => {
   const d1 = utcDate(date1);
   const d2 = utcDate(date2);
 
-  const y1 = Math.abs(d2.year - d1.year) > 0 ? `, ${d1.year}` : ''
-  const m2 = Math.abs(d2.month - d1.month) > 0 ? ` ${monthNames[d2.month]} ` : ''
+  const y1 = Math.abs(d2.year - d1.year) > 0 ? `, ${d1.year}` : '';
+  const m2 =
+    Math.abs(d2.month - d1.month) > 0 ? ` ${monthNames[d2.month]} ` : '';
 
   return {
     start: `${monthNames[d1.month]} ${d1.day}${y1}`,
     end: `${m2}${d2.day}, ${d2.year}`,
-  }
+  };
 };


### PR DESCRIPTION
# Consistent date range formatting for /home

## Intent

As [discussed on Slack](https://wja.slack.com/archives/C02AX66E2S0/p1645003102210779), dates formatted with `date-fns` are displayed relative to the user's local time. This PR uses [this SO answer](https://stackoverflow.com/a/52352512/4416440) to mitigate that.

## Description

I didn't write any unit tests for this yet, but I did some quick manual tests. I added the following code under the existing `<DateRange />` line in _/components/ConferenceHeader.tsx_:
```
          <DateRange startDate={startDate} endDate={endDate} />
          <br /><DateRange startDate={'2022-01-01'} endDate={'2022-01-02'} />
          <br /><DateRange startDate={'2022-01-01'} endDate={endDate} />
          <br /><DateRange startDate={'2021-01-01'} endDate={endDate} />
```

This was the output: 
![image](https://user-images.githubusercontent.com/6001131/154242496-db3b6156-804d-424d-b247-7278f60fa644.png)

I haven't added a special condition for the case where `startDate` and `endDate` are the same.

## Testing this PR

1. `docker-compose up`
2. http://localhost:3000/home
3. Verify that the date range listed in the header matches the formatting that's specified in the Figma design