### PR TITLE
Move <header> to App

### DIFF
--- a/web/pages/[[...slug]].tsx
+++ b/web/pages/[[...slug]].tsx
@@ -5,7 +5,6 @@ import SectionBlock from '../components/SectionBlock';
 import TextBlock from '../components/TextBlock';
 import Heading from '../components/Heading';
 import GridWrapper from '../components/GridWrapper';
-import Nav from '../components/Nav';
 
 const QUERY = groq`
   {
@@ -37,19 +36,14 @@ const Route = ({
   },
 }: RouteProps) => {
   return (
-    <>
-      <header>
-        <Nav />
-      </header>
-      <GridWrapper>
-        <SectionBlock>
-          <Heading>{name}</Heading>
-        </SectionBlock>
-        <SectionBlock>
-          <TextBlock value={sections} />
-        </SectionBlock>
-      </GridWrapper>
-    </>
+    <GridWrapper>
+      <SectionBlock>
+        <Heading>{name}</Heading>
+      </SectionBlock>
+      <SectionBlock>
+        <TextBlock value={sections} />
+      </SectionBlock>
+    </GridWrapper>
   );
 };
 

--- a/web/pages/_app.tsx
+++ b/web/pages/_app.tsx
@@ -2,9 +2,10 @@ import { useEffect } from 'react';
 import { getCookieConsentValue } from 'react-cookie-consent';
 import TagManager from 'react-gtm-module';
 import CookieConsent from '../components/CookieConsent';
+import Nav from '../components/Nav';
 import '../styles/globals.css';
 
-function MyApp({ Component, pageProps }) {
+function MyApp({ Component, pageProps, router }) {
   useEffect(() => {
     const hasConsent = getCookieConsentValue();
     if (
@@ -17,7 +18,13 @@ function MyApp({ Component, pageProps }) {
 
   return (
     <>
-      <Component {...pageProps} />
+      <header>
+        <code>{router.asPath}</code>
+        <Nav />
+      </header>
+      <main>
+        <Component {...pageProps} />
+      </main>
       <CookieConsent />
     </>
   );

--- a/web/pages/_app.tsx
+++ b/web/pages/_app.tsx
@@ -19,7 +19,6 @@ function MyApp({ Component, pageProps, router }) {
   return (
     <>
       <header>
-        <code>{router.asPath}</code>
         <Nav />
       </header>
       <main>

--- a/web/pages/_app.tsx
+++ b/web/pages/_app.tsx
@@ -5,7 +5,7 @@ import CookieConsent from '../components/CookieConsent';
 import Nav from '../components/Nav';
 import '../styles/globals.css';
 
-function MyApp({ Component, pageProps, router }) {
+function MyApp({ Component, pageProps }) {
   useEffect(() => {
     const hasConsent = getCookieConsentValue();
     if (

--- a/web/pages/_document.tsx
+++ b/web/pages/_document.tsx
@@ -112,7 +112,7 @@ class MyDocument extends Document {
             href="/static/images/favicons/favicon-16x16.png"
           />
         </Head>
-        <body className="min-h-screen font-sans antialiased">
+        <body>
           <Main />
           <NextScript />
         </body>

--- a/web/pages/about.tsx
+++ b/web/pages/about.tsx
@@ -7,7 +7,6 @@ import ConferenceUpdatesForm from '../components/ConferenceUpdatesForm';
 import { groq } from 'next-sanity';
 import TextBlock from '../components/TextBlock';
 import { RichTextSection } from '../types/RichTextSection';
-import Nav from '../components/Nav';
 import GridWrapper from '../components/GridWrapper';
 import { getEntityPath } from '../util/entityPaths';
 import { Venue } from '../types/Venue';
@@ -41,77 +40,67 @@ const About = ({
     about: { name, sections },
   },
 }: AboutProps) => (
-  <>
-    <header>
-      <Nav />
-    </header>
-    <GridWrapper>
-      <main>
-        <SectionBlock>
-          <Heading>{name}</Heading>
-        </SectionBlock>
+  <GridWrapper>
+    <SectionBlock>
+      <Heading>{name}</Heading>
+    </SectionBlock>
 
-        <SectionBlock>
-          <TextBlock value={sections} />
-        </SectionBlock>
+    <SectionBlock>
+      <TextBlock value={sections} />
+    </SectionBlock>
 
-        <SectionBlock noBackground>
-          <Paragraph>
-            <Link href="#">Code of Conduct</Link>
-          </Paragraph>
-        </SectionBlock>
+    <SectionBlock noBackground>
+      <Paragraph>
+        <Link href="#">Code of Conduct</Link>
+      </Paragraph>
+    </SectionBlock>
 
-        <SectionBlock noBackground>
-          <Heading type="h2">Conference Locations 2022</Heading>
-          {venues.map((venue) => (
-            <Link href={getEntityPath(venue)} key={venue.title}>
-              <a>
-                <SectionBlock style={{ margin: '1rem 0' }}>
-                  {venue.title}
-                </SectionBlock>
-              </a>
-            </Link>
-          ))}
+    <SectionBlock noBackground>
+      <Heading type="h2">Conference Locations 2022</Heading>
+      {venues.map((venue) => (
+        <Link href={getEntityPath(venue)} key={venue.title}>
+          <a>
+            <SectionBlock style={{ margin: '1rem 0' }}>
+              {venue.title}
+            </SectionBlock>
+          </a>
+        </Link>
+      ))}
 
-          <Heading type="h3">Virtual option info</Heading>
-          <Paragraph>
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum
-            dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit
-            amet, consectetur adipiscing elit. This text is not fetched from
-            Sanity.
-          </Paragraph>
-        </SectionBlock>
+      <Heading type="h3">Virtual option info</Heading>
+      <Paragraph>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum
+        dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet,
+        consectetur adipiscing elit. This text is not fetched from Sanity.
+      </Paragraph>
+    </SectionBlock>
 
-        <SectionBlock>
-          <Heading type="h2">Additional info</Heading>
-          <Paragraph>
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum
-            dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit
-            amet, consectetur adipiscing elit. This text is not fetched from
-            Sanity.
-          </Paragraph>
-        </SectionBlock>
+    <SectionBlock>
+      <Heading type="h2">Additional info</Heading>
+      <Paragraph>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum
+        dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet,
+        consectetur adipiscing elit. This text is not fetched from Sanity.
+      </Paragraph>
+    </SectionBlock>
 
-        <SectionBlock>
-          <Heading type="h2">Sponsor info</Heading>
-          <Paragraph>
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum
-            dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit
-            amet, consectetur adipiscing elit. This text is not fetched from
-            Sanity.
-          </Paragraph>
-          <Heading type="h3">
-            <Link href="#">Become a Sponsor</Link>
-          </Heading>
-        </SectionBlock>
+    <SectionBlock>
+      <Heading type="h2">Sponsor info</Heading>
+      <Paragraph>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum
+        dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet,
+        consectetur adipiscing elit. This text is not fetched from Sanity.
+      </Paragraph>
+      <Heading type="h3">
+        <Link href="#">Become a Sponsor</Link>
+      </Heading>
+    </SectionBlock>
 
-        <SectionBlock>
-          <Heading type="h2">Get conference updates</Heading>
-          <ConferenceUpdatesForm />
-        </SectionBlock>
-      </main>
-    </GridWrapper>
-  </>
+    <SectionBlock>
+      <Heading type="h2">Get conference updates</Heading>
+      <ConferenceUpdatesForm />
+    </SectionBlock>
+  </GridWrapper>
 );
 
 export async function getStaticProps() {

--- a/web/pages/home.tsx
+++ b/web/pages/home.tsx
@@ -9,7 +9,6 @@ import TextBlock from '../components/TextBlock';
 import { Section } from '../types/Section';
 import { Sponsor } from '../types/Sponsor';
 import Sponsors from '../pageResources/home/Sponsors';
-import Nav from '../components/Nav';
 import GridWrapper from '../components/GridWrapper';
 import ConferenceHeader from '../components/ConferenceHeader';
 
@@ -68,56 +67,48 @@ const Home = ({
     sponsors,
   },
 }: HomeProps) => (
-  <>
-    <header>
-      <Nav />
-    </header>
+  <GridWrapper>
+    <ConferenceHeader
+      name={name}
+      startDate={startDate}
+      endDate={endDate}
+      description={description}
+    />
+    <SectionBlock>
+      {microcopy.map(({ key, action, text }) => (
+        <Link key={key} href={action}>
+          {text}
+        </Link>
+      ))}
+    </SectionBlock>
 
-    <GridWrapper>
-      <main>
-        <ConferenceHeader
-          name={name}
-          startDate={startDate}
-          endDate={endDate}
-          description={description}
-        />
-        <SectionBlock>
-          {microcopy.map(({ key, action, text }) => (
-            <Link key={key} href={action}>
-              {text}
-            </Link>
-          ))}
-        </SectionBlock>
+    <SectionBlock>
+      <TextBlock value={valueProposition} />
+    </SectionBlock>
 
-        <SectionBlock>
-          <TextBlock value={valueProposition} />
-        </SectionBlock>
+    <SectionBlock>
+      <Speakers speakers={promotedSpeakers} />
+    </SectionBlock>
 
-        <SectionBlock>
-          <Speakers speakers={promotedSpeakers} />
-        </SectionBlock>
+    <SectionBlock>
+      <Heading type="h2">
+        <Link href="/program">
+          <a>{'Program ->'}</a>
+        </Link>
+      </Heading>
+    </SectionBlock>
 
-        <SectionBlock>
-          <Heading type="h2">
-            <Link href="/program">
-              <a>{'Program ->'}</a>
-            </Link>
-          </Heading>
-        </SectionBlock>
+    <SectionBlock>
+      <Heading type="h2">Sponsors</Heading>
+      <Sponsors sponsors={sponsors} />
+      <Link href="/sponsor">{'Become a Sponsor ->'}</Link>
+    </SectionBlock>
 
-        <SectionBlock>
-          <Heading type="h2">Sponsors</Heading>
-          <Sponsors sponsors={sponsors} />
-          <Link href="/sponsor">{'Become a Sponsor ->'}</Link>
-        </SectionBlock>
-
-        <SectionBlock>
-          <Heading type="h2">Get conference updates</Heading>
-          <ConferenceUpdatesForm />
-        </SectionBlock>
-      </main>
-    </GridWrapper>
-  </>
+    <SectionBlock>
+      <Heading type="h2">Get conference updates</Heading>
+      <ConferenceUpdatesForm />
+    </SectionBlock>
+  </GridWrapper>
 );
 
 export async function getStaticProps() {

--- a/web/pages/program.tsx
+++ b/web/pages/program.tsx
@@ -6,7 +6,6 @@ import Heading from '../components/Heading';
 import Sessions from '../components/Sessions';
 import TextBlock from '../components/TextBlock';
 import { RichTextSection } from '../types/RichTextSection';
-import Nav from '../components/Nav';
 import GridWrapper from '../components/GridWrapper';
 
 const QUERY = `
@@ -39,29 +38,24 @@ const Program = ({
     program: { name, sections },
   },
 }: ProgramProps) => (
-  <>
-    <header>
-      <Nav />
-    </header>
-    <GridWrapper>
-      <main>
-        <SectionBlock>
-          <Heading>{name}</Heading>
-          <Link href="#">Registration</Link>
-        </SectionBlock>
+  <GridWrapper>
+    <main>
+      <SectionBlock>
+        <Heading>{name}</Heading>
+        <Link href="#">Registration</Link>
+      </SectionBlock>
 
-        <SectionBlock>
-          <TextBlock value={sections} />
-        </SectionBlock>
+      <SectionBlock>
+        <TextBlock value={sections} />
+      </SectionBlock>
 
-        <Sessions sessions={sessions} />
+      <Sessions sessions={sessions} />
 
-        <SectionBlock noBackground>
-          <Link href="#">Registration</Link>
-        </SectionBlock>
-      </main>
-    </GridWrapper>
-  </>
+      <SectionBlock noBackground>
+        <Link href="#">Registration</Link>
+      </SectionBlock>
+    </main>
+  </GridWrapper>
 );
 
 export async function getStaticProps() {

--- a/web/pages/sessions/[slug].tsx
+++ b/web/pages/sessions/[slug].tsx
@@ -7,7 +7,6 @@ import Paragraph from '../../components/Paragraph';
 import { formatDateWithTime } from '../../util/date';
 import { Speakers } from '../../pageResources/home/Speakers/Speakers';
 import TextBlock from '../../components/TextBlock';
-import Nav from '../../components/Nav';
 import GridWrapper from '../../components/GridWrapper';
 
 const QUERY = `
@@ -38,43 +37,36 @@ interface SessionPageProps {
 const SessionPage = ({
   data: { title, startTime, location, speakers, longDescription },
 }: SessionPageProps) => (
-  <>
-    <header>
-      <Nav />
-    </header>
-    <GridWrapper>
-      <main>
-        <SectionBlock key={title}>
-          <Heading type="h2">{title}</Heading>
-          <div>
-            {formatDateWithTime(startTime)}, {location.title}
-          </div>
-          {speakers.map(({ name, title }) => (
-            <div key={name}>
-              <strong>{name}</strong>, {title}
-            </div>
-          ))}
-        </SectionBlock>
+  <GridWrapper>
+    <SectionBlock key={title}>
+      <Heading type="h2">{title}</Heading>
+      <div>
+        {formatDateWithTime(startTime)}, {location.title}
+      </div>
+      {speakers.map(({ name, title }) => (
+        <div key={name}>
+          <strong>{name}</strong>, {title}
+        </div>
+      ))}
+    </SectionBlock>
 
-        {longDescription && (
-          <SectionBlock>
-            <TextBlock value={longDescription} />
-          </SectionBlock>
-        )}
+    {longDescription && (
+      <SectionBlock>
+        <TextBlock value={longDescription} />
+      </SectionBlock>
+    )}
 
-        <SectionBlock noBackground>
-          <Heading type="h2">Speakers</Heading>
-          <Speakers speakers={speakers} />
-        </SectionBlock>
+    <SectionBlock noBackground>
+      <Heading type="h2">Speakers</Heading>
+      <Speakers speakers={speakers} />
+    </SectionBlock>
 
-        <SectionBlock noBackground>
-          <Paragraph>
-            <Link href="/program">See full program</Link>
-          </Paragraph>
-        </SectionBlock>
-      </main>
-    </GridWrapper>
-  </>
+    <SectionBlock noBackground>
+      <Paragraph>
+        <Link href="/program">See full program</Link>
+      </Paragraph>
+    </SectionBlock>
+  </GridWrapper>
 );
 
 export async function getServerSideProps({ params: { slug } }) {

--- a/web/pages/speakers/[slug].tsx
+++ b/web/pages/speakers/[slug].tsx
@@ -3,7 +3,6 @@ import Image from 'next/image';
 import client from '../../lib/sanity.server';
 import SectionBlock from '../../components/SectionBlock';
 import Heading from '../../components/Heading';
-import Nav from '../../components/Nav';
 import { imageUrlFor } from '../../lib/sanity';
 import TextBlock from '../../components/TextBlock';
 import { Session } from '../../types/Session';
@@ -44,57 +43,50 @@ const Speakers = ({
     },
   },
 }: SpeakerProps) => (
-  <>
-    <header>
-      <Nav />
-    </header>
-    <GridWrapper>
-      <main>
-        <SectionBlock>
-          <div className={speakerStyles.container}>
-            <div>
-              <Heading>{name}</Heading>
-              <div>{title}</div>
-              <div>
-                <a
-                  href={`https://twitter.com/${twitter}`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  {twitter}
-                </a>
-              </div>
-            </div>
-            <Image
-              src={imageUrlFor(photo).size(200, 200).url()}
-              alt={name}
-              width={200}
-              height={200}
-            />
-          </div>
-        </SectionBlock>
-
-        <SectionBlock>
-          <TextBlock value={bio} />
-        </SectionBlock>
-
-        <Sessions sessions={sessions} />
-
-        <SectionBlock noBackground>
+  <GridWrapper>
+    <SectionBlock>
+      <div className={speakerStyles.container}>
+        <div>
+          <Heading>{name}</Heading>
+          <div>{title}</div>
           <div>
-            <Link href={`/speakers`}>
-              <a>All speakers</a>
-            </Link>
+            <a
+              href={`https://twitter.com/${twitter}`}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {twitter}
+            </a>
           </div>
-          <div>
-            <Link href={`/program`}>
-              <a>See full program</a>
-            </Link>
-          </div>
-        </SectionBlock>
-      </main>
-    </GridWrapper>
-  </>
+        </div>
+        <Image
+          src={imageUrlFor(photo).size(200, 200).url()}
+          alt={name}
+          width={200}
+          height={200}
+        />
+      </div>
+    </SectionBlock>
+
+    <SectionBlock>
+      <TextBlock value={bio} />
+    </SectionBlock>
+
+    <Sessions sessions={sessions} />
+
+    <SectionBlock noBackground>
+      <div>
+        <Link href={`/speakers`}>
+          <a>All speakers</a>
+        </Link>
+      </div>
+      <div>
+        <Link href={`/program`}>
+          <a>See full program</a>
+        </Link>
+      </div>
+    </SectionBlock>
+  </GridWrapper>
 );
 
 export async function getServerSideProps({ params: { slug } }) {

--- a/web/pages/speakers/index.tsx
+++ b/web/pages/speakers/index.tsx
@@ -4,7 +4,6 @@ import client from '../../lib/sanity.server';
 import { imageUrlFor } from '../../lib/sanity';
 import SectionBlock from '../../components/SectionBlock';
 import Heading from '../../components/Heading';
-import Nav from '../../components/Nav';
 import GridWrapper from '../../components/GridWrapper';
 import speakersStyles from '../../pageResources/speakers/Speakers.module.css';
 import { getEntityPath } from '../../util/entityPaths';
@@ -22,50 +21,40 @@ interface SpeakersProps {
 }
 
 const Speakers = ({ data: { speakers } }: SpeakersProps) => (
-  <>
-    <header>
-      <Nav />
-    </header>
-    <GridWrapper>
-      <main>
-        <SectionBlock>
-          <Heading>Speakers</Heading>
-        </SectionBlock>
+  <GridWrapper>
+    <SectionBlock>
+      <Heading>Speakers</Heading>
+    </SectionBlock>
 
-        <SectionBlock noBackground className={speakersStyles.container}>
-          {speakers.map((speaker) => (
-            <div
-              key={speaker._id}
-              className={speakersStyles['container__speaker']}
+    <SectionBlock noBackground className={speakersStyles.container}>
+      {speakers.map((speaker) => (
+        <div key={speaker._id} className={speakersStyles['container__speaker']}>
+          <Link href={getEntityPath(speaker)}>
+            <a>
+              <Image
+                src={imageUrlFor(speaker.photo).size(150, 150).url()}
+                alt={speaker.name}
+                width={150}
+                height={150}
+              />
+            </a>
+          </Link>
+          <div>
+            <div>{speaker.name}</div>
+            <div>{speaker.title}</div>
+            <a
+              className={speakersStyles.speakerTwitter}
+              href={`https://twitter.com/${speaker.social.twitter}`}
+              target="_blank"
+              rel="noopener noreferrer"
             >
-              <Link href={getEntityPath(speaker)}>
-                <a>
-                  <Image
-                    src={imageUrlFor(speaker.photo).size(150, 150).url()}
-                    alt={speaker.name}
-                    width={150}
-                    height={150}
-                  />
-                </a>
-              </Link>
-              <div>
-                <div>{speaker.name}</div>
-                <div>{speaker.title}</div>
-                <a
-                  className={speakersStyles.speakerTwitter}
-                  href={`https://twitter.com/${speaker.social.twitter}`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  {speaker.social.twitter}
-                </a>
-              </div>
-            </div>
-          ))}
-        </SectionBlock>
-      </main>
-    </GridWrapper>
-  </>
+              {speaker.social.twitter}
+            </a>
+          </div>
+        </div>
+      ))}
+    </SectionBlock>
+  </GridWrapper>
 );
 
 export async function getStaticProps() {

--- a/web/pages/sponsor.tsx
+++ b/web/pages/sponsor.tsx
@@ -2,7 +2,6 @@ import client from '../lib/sanity.server';
 import SectionBlock from '../components/SectionBlock';
 import Heading from '../components/Heading';
 import sponsorStyles from '../pageResources/sponsor/Sponsor.module.css';
-import Nav from '../components/Nav';
 import Paragraph from '../components/Paragraph';
 import Link from 'next/link';
 import GridWrapper from '../components/GridWrapper';
@@ -14,119 +13,109 @@ interface SponsorProps {
 }
 
 const Sponsor = ({ data: {} }: SponsorProps) => (
-  <>
-    <header>
-      <Nav />
-    </header>
-    <GridWrapper>
-      <main>
-        <SectionBlock>
-          <Heading>Sponsor partner</Heading>
-          <Paragraph>
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum
-            dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit
-            amet, consectetur adipiscing elit. This text is not fetched from
-            Sanity.
-          </Paragraph>
+  <GridWrapper>
+    <SectionBlock>
+      <Heading>Sponsor partner</Heading>
+      <Paragraph>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum
+        dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet,
+        consectetur adipiscing elit. This text is not fetched from Sanity.
+      </Paragraph>
 
-          <Link href="#signUp">
-            <a>{'Sign up ->'}</a>
-          </Link>
-        </SectionBlock>
+      <Link href="#signUp">
+        <a>{'Sign up ->'}</a>
+      </Link>
+    </SectionBlock>
 
-        <SectionBlock>
-          <Heading type="h2">Lorem ipsum</Heading>
-          <Paragraph>
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum
-            dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit
-            amet, consectetur adipiscing elit. This text is not fetched from
-            Sanity.
-          </Paragraph>
-        </SectionBlock>
+    <SectionBlock>
+      <Heading type="h2">Lorem ipsum</Heading>
+      <Paragraph>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum
+        dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet,
+        consectetur adipiscing elit. This text is not fetched from Sanity.
+      </Paragraph>
+    </SectionBlock>
 
-        <SectionBlock>
-          <table className={sponsorStyles.table}>
-            <thead>
-              <tr>
-                <th />
-                <th>Premier</th>
-                <th>Gold</th>
-                <th>Silver</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td>Description</td>
-                <td>✅</td>
-                <td>✅</td>
-                <td>✅</td>
-              </tr>
-              <tr>
-                <td>Description</td>
-                <td>✅</td>
-                <td>✅</td>
-                <td />
-              </tr>
-              <tr>
-                <td>Description</td>
-                <td>✅</td>
-                <td>✅</td>
-                <td />
-              </tr>
-              <tr>
-                <td>Description</td>
-                <td>✅</td>
-                <td />
-                <td />
-              </tr>
-              <tr>
-                <td>Description</td>
-                <td>✅</td>
-                <td />
-                <td />
-              </tr>
-              <tr>
-                <td>Description</td>
-                <td>✅</td>
-                <td />
-                <td />
-              </tr>
-            </tbody>
-          </table>
-        </SectionBlock>
+    <SectionBlock>
+      <table className={sponsorStyles.table}>
+        <thead>
+          <tr>
+            <th />
+            <th>Premier</th>
+            <th>Gold</th>
+            <th>Silver</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Description</td>
+            <td>✅</td>
+            <td>✅</td>
+            <td>✅</td>
+          </tr>
+          <tr>
+            <td>Description</td>
+            <td>✅</td>
+            <td>✅</td>
+            <td />
+          </tr>
+          <tr>
+            <td>Description</td>
+            <td>✅</td>
+            <td>✅</td>
+            <td />
+          </tr>
+          <tr>
+            <td>Description</td>
+            <td>✅</td>
+            <td />
+            <td />
+          </tr>
+          <tr>
+            <td>Description</td>
+            <td>✅</td>
+            <td />
+            <td />
+          </tr>
+          <tr>
+            <td>Description</td>
+            <td>✅</td>
+            <td />
+            <td />
+          </tr>
+        </tbody>
+      </table>
+    </SectionBlock>
 
-        <SectionBlock>
-          <Heading type="h2" id="signUp">
-            Sign up
-          </Heading>
-          <Paragraph>
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum
-            dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit
-            amet, consectetur adipiscing elit. This text is not fetched from
-            Sanity.
-          </Paragraph>
+    <SectionBlock>
+      <Heading type="h2" id="signUp">
+        Sign up
+      </Heading>
+      <Paragraph>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum
+        dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet,
+        consectetur adipiscing elit. This text is not fetched from Sanity.
+      </Paragraph>
 
-          <form
-            className={sponsorStyles.form}
-            onSubmit={() => alert('This form is not yet implemented.')}
-          >
-            <label htmlFor="company">Your company</label>
-            <input type="text" name="company" />
+      <form
+        className={sponsorStyles.form}
+        onSubmit={() => alert('This form is not yet implemented.')}
+      >
+        <label htmlFor="company">Your company</label>
+        <input type="text" name="company" />
 
-            <label htmlFor="name">Your name</label>
-            <input type="text" name="name" />
+        <label htmlFor="name">Your name</label>
+        <input type="text" name="name" />
 
-            <label htmlFor="mail">Email</label>
-            <input type="email" />
+        <label htmlFor="mail">Email</label>
+        <input type="email" />
 
-            <button type="submit" className={sponsorStyles.button}>
-              Submit
-            </button>
-          </form>
-        </SectionBlock>
-      </main>
-    </GridWrapper>
-  </>
+        <button type="submit" className={sponsorStyles.button}>
+          Submit
+        </button>
+      </form>
+    </SectionBlock>
+  </GridWrapper>
 );
 
 export async function getStaticProps() {

--- a/web/pages/tickets.tsx
+++ b/web/pages/tickets.tsx
@@ -2,7 +2,6 @@ import client from '../lib/sanity.server';
 import SectionBlock from '../components/SectionBlock';
 import Heading from '../components/Heading';
 import ticketsStyles from '../pageResources/tickets/Tickets.module.css';
-import Nav from '../components/Nav';
 import { RichTextSection } from '../types/RichTextSection';
 import TextBlock from '../components/TextBlock';
 import GridWrapper from '../components/GridWrapper';
@@ -42,53 +41,44 @@ const Tickets = ({
     registrationInfo: { name, sections },
   },
 }: TicketsProps) => (
-  <>
-    <header>
-      <Nav />
-    </header>
-    <GridWrapper>
-      <main>
-        <SectionBlock>
-          <Heading>Tickets</Heading>
-        </SectionBlock>
+  <GridWrapper>
+    <SectionBlock>
+      <Heading>Tickets</Heading>
+    </SectionBlock>
 
-        <SectionBlock noBackground>
-          <div className={ticketsStyles.container}>
-            {tickets.map((ticket) => (
-              <div key={ticket._id} className={ticketsStyles.ticket}>
-                <div className={ticketsStyles['ticket__type']}>
-                  {ticket.type}
+    <SectionBlock noBackground>
+      <div className={ticketsStyles.container}>
+        {tickets.map((ticket) => (
+          <div key={ticket._id} className={ticketsStyles.ticket}>
+            <div className={ticketsStyles['ticket__type']}>{ticket.type}</div>
+            <div className={ticketsStyles['ticket__price']}>
+              <span className={ticketsStyles['ticket__price__currency']}>
+                $
+              </span>
+              <span className={ticketsStyles['ticket__price__amount']}>
+                {ticket.price}
+              </span>
+            </div>
+            <div className={ticketsStyles['ticket__included']}>
+              {ticket.included?.map((included) => (
+                <div
+                  key={included}
+                  className={ticketsStyles['ticket__included__item']}
+                >
+                  {included}
                 </div>
-                <div className={ticketsStyles['ticket__price']}>
-                  <span className={ticketsStyles['ticket__price__currency']}>
-                    $
-                  </span>
-                  <span className={ticketsStyles['ticket__price__amount']}>
-                    {ticket.price}
-                  </span>
-                </div>
-                <div className={ticketsStyles['ticket__included']}>
-                  {ticket.included?.map((included) => (
-                    <div
-                      key={included}
-                      className={ticketsStyles['ticket__included__item']}
-                    >
-                      {included}
-                    </div>
-                  ))}
-                </div>
-              </div>
-            ))}
+              ))}
+            </div>
           </div>
-        </SectionBlock>
+        ))}
+      </div>
+    </SectionBlock>
 
-        <SectionBlock>
-          <Heading>{name}</Heading>
-          <TextBlock value={sections} />
-        </SectionBlock>
-      </main>
-    </GridWrapper>
-  </>
+    <SectionBlock>
+      <Heading>{name}</Heading>
+      <TextBlock value={sections} />
+    </SectionBlock>
+  </GridWrapper>
 );
 
 export async function getStaticProps() {

--- a/web/pages/venues/[slug].tsx
+++ b/web/pages/venues/[slug].tsx
@@ -5,7 +5,6 @@ import SectionBlock from '../../components/SectionBlock';
 import Heading from '../../components/Heading';
 import Paragraph from '../../components/Paragraph';
 import GridWrapper from '../../components/GridWrapper';
-import Nav from '../../components/Nav';
 import styles from '../../pageResources/about/venue/venue.module.css';
 
 const QUERY = `
@@ -23,63 +22,54 @@ const mapUrl = (geolocation: { lat: number; lng: number }) =>
   `https://maps.google.com/maps?q=${geolocation.lat},${geolocation.lng}&t=&z=15&ie=UTF8&iwloc=&output=embed`;
 
 const Venue = ({ data: { title, geolocation } }: VenueProps) => (
-  <>
-    <header>
-      <Nav />
-    </header>
-    <GridWrapper>
-      <main>
-        <SectionBlock>
-          <Heading>{title}</Heading>
-        </SectionBlock>
+  <GridWrapper>
+    <SectionBlock>
+      <Heading>{title}</Heading>
+    </SectionBlock>
 
-        <SectionBlock>
-          <div className={styles.location}>
-            <div>
-              <Heading type="h2">Location</Heading>
-              <Paragraph>
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem
-                ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum
-                dolor sit amet, consectetur adipiscing elit. This text is not
-                fetched from Sanity.
-              </Paragraph>
-            </div>
-            <div className={styles.map}>
-              {geolocation?.lat && geolocation?.lng && (
-                <iframe src={mapUrl(geolocation)} />
-              )}
-            </div>
-          </div>
-        </SectionBlock>
-
-        <SectionBlock>
-          <Heading type="h2">Attendee details</Heading>
+    <SectionBlock>
+      <div className={styles.location}>
+        <div>
+          <Heading type="h2">Location</Heading>
           <Paragraph>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum
             dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit
             amet, consectetur adipiscing elit. This text is not fetched from
             Sanity.
           </Paragraph>
-        </SectionBlock>
+        </div>
+        <div className={styles.map}>
+          {geolocation?.lat && geolocation?.lng && (
+            <iframe src={mapUrl(geolocation)} />
+          )}
+        </div>
+      </div>
+    </SectionBlock>
 
-        <SectionBlock>
-          <Heading type="h2">Associated company/contact</Heading>
-          <Paragraph>
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum
-            dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit
-            amet, consectetur adipiscing elit. This text is not fetched from
-            Sanity.
-          </Paragraph>
-        </SectionBlock>
+    <SectionBlock>
+      <Heading type="h2">Attendee details</Heading>
+      <Paragraph>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum
+        dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet,
+        consectetur adipiscing elit. This text is not fetched from Sanity.
+      </Paragraph>
+    </SectionBlock>
 
-        <SectionBlock noBackground>
-          <Paragraph>
-            <Link href="#">{'See program for this venue ->'}</Link>
-          </Paragraph>
-        </SectionBlock>
-      </main>
-    </GridWrapper>
-  </>
+    <SectionBlock>
+      <Heading type="h2">Associated company/contact</Heading>
+      <Paragraph>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum
+        dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet,
+        consectetur adipiscing elit. This text is not fetched from Sanity.
+      </Paragraph>
+    </SectionBlock>
+
+    <SectionBlock noBackground>
+      <Paragraph>
+        <Link href="#">{'See program for this venue ->'}</Link>
+      </Paragraph>
+    </SectionBlock>
+  </GridWrapper>
 );
 
 export async function getServerSideProps({ params: { slug } }) {


### PR DESCRIPTION
# Move <header> to App

## Intent

Moves the shared "global" `<header>`, along with the `<Nav>` inside, to the `<App>` component. This is in preparation for implementing the sticky header (and/or footer placement), to try to avoid duplicating any logic/styling that may need to exist outside.

## Description

Earlier we discussed moving things into `_document`, but it looks like that's not going to work very well according to [the docs](https://nextjs.org/docs/advanced-features/custom-document#caveats). I accidentally committed/pushed a Tailwind class removal in that file regardless, but might as well leave that in.

Having the shared stuff in App seems to be the intended way according to the aforementioned docs. Previously we didn't really know if the header/footer would be shared, but now we do. And hopefully this new placement will enable adjusting the overall page layout (e.g. introducing extra wrappers, styling or logic if necessary) without touching all the `web/pages`.

This change _does_ touch all the web/pages, though, hence scoping this PR to try to get that part over with as soon as possible.

## Testing this PR

1. `docker-compose up web`
2. Open http://localhost:3000/ and a few different pages, e.g. clicking the links in the header menu, and verify that there is exactly one such header menu on each page