### PR TITLE
Sticky header

### DIFF
--- a/web/components/Nav/Nav.module.css
+++ b/web/components/Nav/Nav.module.css
@@ -1,4 +1,5 @@
 .nav {
+  background: var(--color-brand-white);
   box-shadow: 0 6px 0 rgba(0, 0, 0, 0.1);
 }
 
@@ -41,13 +42,14 @@
 
 @media not all and (--medium-up) {
   .nav {
+    background: none;
     box-shadow: none;
   }
 
   .menuButtonWrapper {
     display: block;
-    text-align: right;
-    padding: 24px 0;
+    padding-bottom: 46px;
+    text-align: center;
   }
 
   .menuButton,
@@ -94,11 +96,10 @@
     bottom: 0;
     left: 0;
     right: 0;
-    z-index: 1;
     background: var(--color-brand-yellow);
     flex-direction: column;
     align-items: start;
-    padding: 24px var(--grid-half-gutter);
+    padding: 24px var(--grid-half-gutter) 36px;
     overflow: auto;
   }
 

--- a/web/components/Nav/Nav.tsx
+++ b/web/components/Nav/Nav.tsx
@@ -14,6 +14,8 @@ export const Nav = () => {
     document.body.classList.toggle('main-menu-open', menuOpened);
   }, [menuOpened]);
 
+  const closeMenu = () => setMenuOpened(false);
+
   return (
     <nav className={styles.nav}>
       <GridWrapper>
@@ -47,22 +49,22 @@ export const Nav = () => {
           <ul className={styles.items}>
             <li className={styles.ticketItem}>
               <Link href="/tickets">
-                <a className={styles.link}>Tickets</a>
+                <a className={styles.link} onClick={closeMenu}>Tickets</a>
               </Link>
             </li>
             <li>
               <Link href="/program">
-                <a className={styles.link}>Program</a>
+                <a className={styles.link} onClick={closeMenu}>Program</a>
               </Link>
             </li>
             <li>
               <Link href="/speakers">
-                <a className={styles.link}>Speakers</a>
+                <a className={styles.link} onClick={closeMenu}>Speakers</a>
               </Link>
             </li>
             <li>
               <Link href="/about">
-                <a className={styles.link}>About</a>
+                <a className={styles.link} onClick={closeMenu}>About</a>
               </Link>
             </li>
           </ul>
@@ -72,7 +74,7 @@ export const Nav = () => {
           <button
             type="button"
             className={styles.closeButton}
-            onClick={() => setMenuOpened(false)}
+            onClick={closeMenu}
           >
             Close
           </button>

--- a/web/components/Nav/Nav.tsx
+++ b/web/components/Nav/Nav.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx';
 import Link from 'next/link';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import ButtonLink from '../ButtonLink';
 import GridWrapper from '../GridWrapper';
 import logo from '../../images/logo.svg';
@@ -9,6 +9,10 @@ import styles from './Nav.module.css';
 export const Nav = () => {
   const [menuOpened, setMenuOpened] = useState(false);
   const contentsId = 'nav-menu-contents';
+
+  useEffect(() => {
+    document.body.classList.toggle('main-menu-open', menuOpened);
+  }, [menuOpened]);
 
   return (
     <nav className={styles.nav}>

--- a/web/pages/App.module.css
+++ b/web/pages/App.module.css
@@ -1,0 +1,28 @@
+.header {
+  width: 100%;
+  z-index: 1;
+}
+
+.cookieConsent {
+  position: relative;
+  z-index: 2;
+}
+
+/* Separate media query ensures IE11 can fall back to static position for
+ * medium-up
+ */
+@media not all and (--medium-up) {
+  .header {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+  }
+}
+
+@media (--medium-up) {
+  .header {
+    position: sticky;
+    top: 0;
+    left: 0;
+  }
+}

--- a/web/pages/_app.tsx
+++ b/web/pages/_app.tsx
@@ -1,12 +1,15 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { getCookieConsentValue } from 'react-cookie-consent';
 import TagManager from 'react-gtm-module';
+import clsx from 'clsx';
 import CookieConsent from '../components/CookieConsent';
 import Nav from '../components/Nav';
 import '../styles/globals.css';
 import styles from './app.module.css';
 
-function MyApp({ Component, pageProps }) {
+function MyApp({ Component, pageProps, router }) {
+  const [scrollTop, setScrollTop] = useState(0);
+
   useEffect(() => {
     const hasConsent = getCookieConsentValue();
     if (
@@ -17,9 +20,33 @@ function MyApp({ Component, pageProps }) {
     }
   }, []);
 
+  /* This is a hack. What we really want is to enable the menu once we've
+   * scrolled past the top logo on the front page. Probably a better way would
+   * be to give the page a callback so it can use IntersectionObserver and
+   * notify us when the right elements have appeared/disappeared from view.
+   */
+  const scrollPositionTriggeringFrontPageMenu = 420;
+
+  useEffect(() => {
+    const onScroll = e => {
+      setScrollTop(e.target.documentElement.scrollTop);
+    };
+    window.addEventListener('scroll', onScroll);
+
+    return () => window.removeEventListener('scroll', onScroll);
+  }, [scrollTop]);
+
+  const isFrontPage = router.asPath === '/home' || router.asPath === '/';
+  const scrolledFarEnough = scrollTop > scrollPositionTriggeringFrontPageMenu;
+  const headerClasses = clsx(
+    styles.header,
+    isFrontPage && styles.onFrontPage,
+    isFrontPage && scrolledFarEnough && styles.onScrolledFrontPage
+  );
+
   return (
     <>
-      <header className={styles.header}>
+      <header className={headerClasses}>
         <Nav />
       </header>
       <main>

--- a/web/pages/_app.tsx
+++ b/web/pages/_app.tsx
@@ -8,7 +8,9 @@ import '../styles/globals.css';
 import styles from './app.module.css';
 
 function MyApp({ Component, pageProps, router }) {
-  const [scrollTop, setScrollTop] = useState(0);
+  const [scrollTop, setScrollTop] = useState(
+    typeof document !== 'undefined' ? document.documentElement.scrollTop : 0
+  );
 
   useEffect(() => {
     const hasConsent = getCookieConsentValue();
@@ -28,7 +30,7 @@ function MyApp({ Component, pageProps, router }) {
   const scrollPositionTriggeringFrontPageMenu = 420;
 
   useEffect(() => {
-    const onScroll = e => {
+    const onScroll = (e) => {
       setScrollTop(e.target.documentElement.scrollTop);
     };
     window.addEventListener('scroll', onScroll);

--- a/web/pages/_app.tsx
+++ b/web/pages/_app.tsx
@@ -4,6 +4,7 @@ import TagManager from 'react-gtm-module';
 import CookieConsent from '../components/CookieConsent';
 import Nav from '../components/Nav';
 import '../styles/globals.css';
+import styles from './app.module.css';
 
 function MyApp({ Component, pageProps }) {
   useEffect(() => {
@@ -18,13 +19,15 @@ function MyApp({ Component, pageProps }) {
 
   return (
     <>
-      <header>
+      <header className={styles.header}>
         <Nav />
       </header>
       <main>
         <Component {...pageProps} />
       </main>
-      <CookieConsent />
+      <div className={styles.cookieConsent}>
+        <CookieConsent />
+      </div>
     </>
   );
 }

--- a/web/pages/app.module.css
+++ b/web/pages/app.module.css
@@ -1,0 +1,28 @@
+.header {
+  width: 100%;
+  z-index: 1;
+}
+
+.cookieConsent {
+  position: relative;
+  z-index: 2;
+}
+
+/* Separate media query ensures IE11 can fall back to static position for
+ * medium-up
+ */
+@media not all and (--medium-up) {
+  .header {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+  }
+}
+
+@media (--medium-up) {
+  .header {
+    position: sticky;
+    top: 0;
+    left: 0;
+  }
+}

--- a/web/pages/app.module.css
+++ b/web/pages/app.module.css
@@ -25,4 +25,13 @@
     top: 0;
     left: 0;
   }
+
+  .header.onFrontPage {
+    position: fixed;
+    display: none;
+  }
+
+  .header.onScrolledFrontPage {
+    display: block;
+  }
 }

--- a/web/styles/globals.css
+++ b/web/styles/globals.css
@@ -39,6 +39,10 @@ body {
     Noto Color Emoji;
 }
 
+body.main-menu-open {
+  overflow: hidden;
+}
+
 p,
 ul {
   margin: 0;
@@ -47,4 +51,10 @@ ul {
 
 a {
   text-decoration: underline;
+}
+
+@media (--medium-up) {
+  body.main-menu-open {
+    overflow: auto;
+  }
 }


### PR DESCRIPTION
# Sticky header

## Intent

Make the header "sticky" as specified by the designer, and make a couple other small fixes to the header/menu

## Description
- Disables scrolling the viewport when the mobile menu is open, to avoid wonky behavior there (e.g. when swiping on my phone I would get a scrollbar and the menu jumped around)
- Fixes a bug where the mobile menu didn't close after a link was clicked
- Moves mobile menu button to the bottom of the viewport, instead of the top right of the page. This button is fixed at that position on all pages.
- On most pages, the header/menu for wider screens is likewise fixed to the viewport, only to the top instead.
- On the front page in particular, however, the header/menu is completely hidden unless the page is scrolled sufficiently far down. (Round about the point where the logo is scrolled out of the screen.)

I enabled this last exception both for `/home` and for `/` which will be the new home page. Upside of this is that we don't have to remember it once /home is retired, but downside is that there is no menu until the page is tall enough… (except mobile)

## Testing this PR

1. `docker-compose up web`
2. Open http://localhost:3000/home and verify that the header is absent
3. Scroll down and verify that the header eventually appears
4. Click the link to another page (e.g. Program) and verify that the header is present at all times
5. Shrink window to mobile-ish width and verify that the menu button appears at the bottom (if you've clicked away the cookie consent dialog)
6. Click the Menu button and verify that the viewport is no longer (vertically) scrollable, i.e. that you can't scroll the page that still exists behind the menu
7. Click a link and verify that the menu is closed, navigation to the linked page happens, and viewport scrollbar is back if the page is tall enough to require it (e.g. About should work, unless the screen is extremely tall!)