### PR TITLE
Registration info page

### DIFF
--- a/web/components/TextBlock/QuestionAndAnswerCollection.module.css
+++ b/web/components/TextBlock/QuestionAndAnswerCollection.module.css
@@ -1,0 +1,3 @@
+.question:not(:last-child) {
+  padding-bottom: 1rem;
+}

--- a/web/components/TextBlock/QuestionAndAnswerCollection.tsx
+++ b/web/components/TextBlock/QuestionAndAnswerCollection.tsx
@@ -1,18 +1,20 @@
 import Heading from '../Heading';
 import { Block } from './Block';
+import SectionBlock from '../SectionBlock';
+import styles from './QuestionAndAnswerCollection.module.css';
 
 export const QuestionAndAnswerCollection = ({
   value: { questions, title },
 }) => (
-  <>
+  <SectionBlock>
     <Heading type="h2">{title}</Heading>
     {questions.map(({ _key, question, answer }) => (
-      <div key={_key}>
+      <div key={_key} className={styles.question}>
         <Heading type="h3">{question}</Heading>
         {answer.map((value) => (
           <Block key={value._key} value={value} />
         ))}
       </div>
     ))}
-  </>
+  </SectionBlock>
 );

--- a/web/components/TextBlock/RichText.tsx
+++ b/web/components/TextBlock/RichText.tsx
@@ -1,11 +1,8 @@
-import Paragraph from '../Paragraph';
+import { TextBlock } from './TextBlock';
+import SectionBlock from '../SectionBlock';
 
 export const RichText = ({ value }) => (
-  <>
-    {value.content
-      .reduce((acc, content) => [...acc, ...content.children], [])
-      .map((children) => (
-        <Paragraph key={children._key}>{children.text}</Paragraph>
-      ))}
-  </>
+  <SectionBlock>
+    <TextBlock value={value.content} />
+  </SectionBlock>
 );

--- a/web/components/TextBlock/SharedSections.tsx
+++ b/web/components/TextBlock/SharedSections.tsx
@@ -1,6 +1,7 @@
 import Image from 'next/image';
 import { imageUrlFor } from '../../lib/sanity';
 import Heading from '../Heading';
+import { RichText } from './RichText';
 
 const MailchimpSection = ({ value: { buttonText, id, title } }) => (
   <form>
@@ -29,6 +30,8 @@ export const SharedSections = ({ value: { name, sections } }) => (
           return <MailchimpSection key={section._key} value={section} />;
         case 'figure':
           return <Figure key={section._key} value={section} />;
+        case 'richText':
+          return <RichText key={section._key} value={section} />;
         default:
           console.error(
             `Unrecognized SharedSections section type '${section._type}'`

--- a/web/pages/[[...slug]].tsx
+++ b/web/pages/[[...slug]].tsx
@@ -43,9 +43,7 @@ const Route = ({
       <SectionBlock>
         <Heading>{name}</Heading>
       </SectionBlock>
-      <SectionBlock>
-        <TextBlock value={sections} />
-      </SectionBlock>
+      <TextBlock value={sections} />
     </GridWrapper>
   );
 };

--- a/web/util/date.ts
+++ b/web/util/date.ts
@@ -27,7 +27,10 @@ const utcDate = (date: string) => {
   };
 };
 
-export const formatDateRangeInUtc = (timestamp1: string, timestamp2: string) => {
+export const formatDateRangeInUtc = (
+  timestamp1: string,
+  timestamp2: string
+) => {
   const d1 = utcDate(timestamp1);
   const d2 = utcDate(timestamp2);
 


### PR DESCRIPTION
# Registration info page

## Intent

- Renders `richText`-type blocks from Sanity correctly
- Renders the [Registration info](http://localhost:3333/desk/page;8e0a4c73-2b2a-43c9-84a4-7a00c286aa86) document content correctly at [/registration-info](http://localhost:3000/registration-info) (content only, no styling)

## Description

As mentioned in a454e72146c33ae6cca5500e13d9296b60fb0499, I realized that `<TextBlock />`, rather than its parent element, needs to decide how to render sections along with their wrappers. This allows rendering each section with the (eventually) correct styling, like so:
![image](https://user-images.githubusercontent.com/6001131/154652230-a9252df0-0ee2-4620-a73c-8dd3ca8d24f4.png)

For comparison, the same page renders this way on current `staging`: 
![image](https://user-images.githubusercontent.com/6001131/154652349-71dcaa5e-6047-4872-94bf-9444e0fcc207.png)

This requires placing more responsibility into `<TextBlock />`, which was initially somewhat counter-intuitive to me, but seems to match up with www-sanity-io's approach. 

I also tested creating a Sanity "Section" and outputting text with every formatting option available, which seemed to work as expected.
![image](https://user-images.githubusercontent.com/6001131/154651299-ca92840f-94a3-44ea-8c06-1f4d6442a259.png)
(Left is Sanity, right is localhost.)


## Testing this PR

1. `docker-compose up`
2. Go to http://localhost:3000/registration-info and verify that all the Sections of the [corresponding Landing Page in Studio](http://localhost:3333/desk/page;8e0a4c73-2b2a-43c9-84a4-7a00c286aa86) are rendered. (Make sure that the latest version is published, we don't render drafts. You can tell you're viewing a draft when you click the meatballs menu -> "Inspect" and the displayed `_id` field's value is prefixed with `draft.`)