### PR TITLE
Conference header style tweaks

### DIFF
--- a/web/components/ConferenceHeader/ConferenceHeader.module.css
+++ b/web/components/ConferenceHeader/ConferenceHeader.module.css
@@ -1,5 +1,5 @@
 .root {
-  margin: var(--spacing-small) 0 var(--spacing-large);
+  margin: 24px 0 80px;
 }
 
 .logo {
@@ -8,16 +8,44 @@
 }
 
 .summary {
-  margin-top: var(--spacing-small);
-  font: var(--font-body-large-medium);
-  letter-spacing: var(--letter-spacing-body-large);
+  margin-top: 24px;
+  font: var(--font-body-base-medium);
+  letter-spacing: var(--letter-spacing-body-base);
   display: grid;
-  row-gap: var(--spacing-small);
+  row-gap: 24px;
+}
+
+@media (--medium-up) {
+  .root {
+    margin: 32px 0 96px;
+  }
+
+  .summary {
+    margin-top: 32px;
+    column-gap: var(--grid-medium-gutter);
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .dates {
+    font: var(--font-body-xl-medium);
+    letter-spacing: var(--letter-spacing-body-xl);
+  }
 }
 
 @media (--large-up) {
+  .root {
+    margin: 40px 0 128px;
+  }
+
   .summary {
+    margin-top: 40px;
     column-gap: var(--grid-gutter);
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+    font: var(--font-body-xl-medium);
+    letter-spacing: var(--letter-spacing-body-xl);
+  }
+
+  .dates {
+    font: var(--font-ui-xxl-medium);
+    letter-spacing: var(--letter-spacing-ui-xxl);
   }
 }

--- a/web/components/ConferenceHeader/ConferenceHeader.tsx
+++ b/web/components/ConferenceHeader/ConferenceHeader.tsx
@@ -28,7 +28,7 @@ export const ConferenceHeader = ({
         />
       </h1>
       <div className={styles.summary}>
-        <p>
+        <p className={styles.dates}>
           <DateRange startTimestamp={startDate} endTimestamp={endDate} />
         </p>
         <p>{description}</p>

--- a/web/components/GridWrapper/GridWrapper.module.css
+++ b/web/components/GridWrapper/GridWrapper.module.css
@@ -6,6 +6,12 @@
 
 @media (--medium-up) {
   .container {
+    padding: 0 var(--grid-medium-gutter);
+  }
+}
+
+@media (--large-up) {
+  .container {
     padding: 0 var(--grid-gutter);
   }
 }

--- a/web/styles/variables.css
+++ b/web/styles/variables.css
@@ -10,10 +10,12 @@
   --color-ui-gray-100: #f4f3ef;
   --font-body-base-medium: 500 18px/25px 'Inter', sans-serif;
   --font-body-large-medium: 500 20px/30px 'Inter', sans-serif;
+  --font-body-xl-medium: 500 24px/33px 'Inter', sans-serif;
   --font-display-base: 700 40px/39px sans-serif; /* Web font not received yet */
   --font-display-lg: 700 64px/64px sans-serif; /* Web font not received yet */
   --font-display-sm: 700 32px/35px sans-serif; /* Web font not received yet */
   --font-ui-sm-medium: 500 16px/22px 'Inter', sans-serif;
+  --font-ui-xxl-medium: 500 40px/56px 'Inter', sans-serif;
   --grid-gutter: 40px;
   --grid-half-gutter: 20px;
   --grid-medium-gutter: 32px; /* These could be set in @media if we drop IE11 */
@@ -21,7 +23,9 @@
   --grid-width: 1440px;
   --letter-spacing-body-base: -0.014em;
   --letter-spacing-body-large: -0.017em;
+  --letter-spacing-body-xl: -0.019em;
   --letter-spacing-ui-sm: -0.011em;
+  --letter-spacing-ui-xxl: -0.022em;
   --spacing-small: 40px;
   --spacing-medium: 64px;
   --spacing-large: 128px;

--- a/web/styles/variables.css
+++ b/web/styles/variables.css
@@ -16,6 +16,8 @@
   --font-ui-sm-medium: 500 16px/22px 'Inter', sans-serif;
   --grid-gutter: 40px;
   --grid-half-gutter: 20px;
+  --grid-medium-gutter: 32px; /* These could be set in @media if we drop IE11 */
+  --grid-medium-half-gutter: 16px;
   --grid-width: 1440px;
   --letter-spacing-body-base: -0.014em;
   --letter-spacing-body-large: -0.017em;


### PR DESCRIPTION
# Conference header style tweaks

## Intent

Update styling of the conference header (giant logo + dates + intro on the front page) to match the new "V2" Figma sketch

## Description

I actually already had on my todo list to update this one per the mobile+tablet sketches, which did not exist at the time when I initially made this component.

So this PR consists of
- some font/spacing tweaks, reflecting the mobile/tablet/desktop differences in the sketch
- in particular, making the conference dates ("May 25–26, 2022") larger on tablet and desktop, which is new in V2 of the design

## Testing this PR

1. Open https://structured-content-2022-web-git-conference-header-style-tweaks.sanity.build/home
2. Make sure the viewport is fairly wide (e.g. fullscreen on a laptop/desktop; minimum 1440px) and verify that the date range to the bottom left of the main logo has a bigger text size than the blurb paragraph on the right
3. Shrink viewport to around 800px width, e.g. via the iPad preset in Firefox dev tools' "Responsive Design Mode", and verify that the aforementioned dates + blurb paragraph still appear in two separate columns side by side
4. Shrink viewport further down to around 320px–400px width (e.g. some iPhone preset in Responsive Design Mode) and verify that the text (now stacked in one column) looks OK, with generally smaller text size