### PR TITLE
Navblock refactor & rearrange items to match V2 Figma sketch

### DIFF
--- a/web/components/NavBlock/NavBlock.tsx
+++ b/web/components/NavBlock/NavBlock.tsx
@@ -23,17 +23,18 @@ const FakeItem = ({ divider, mobile, tablet, desktop }: FakeItemProps) =>
 export const NavBlock = () => (
   <nav className={styles.nav}>
     <ul className={styles.list}>
+      <FakeItem mobile />
       <li className={styles.item}>
         <Link href="/program">
           <a className={styles.link}>Program</a>
         </Link>
       </li>
 
-      <FakeItem mobile tablet desktop />
+      <FakeItem tablet desktop />
       <FakeItem tablet desktop />
       <FakeItem desktop />
       <FakeItem divider mobile tablet desktop />
-      <FakeItem mobile tablet desktop />
+      <FakeItem tablet desktop />
       <FakeItem tablet desktop />
       <FakeItem desktop />
 
@@ -43,7 +44,9 @@ export const NavBlock = () => (
         </Link>
       </li>
 
+      <FakeItem mobile />
       <FakeItem divider mobile tablet desktop />
+      <FakeItem mobile />
 
       <li className={styles.item}>
         <Link href="/about">
@@ -51,9 +54,8 @@ export const NavBlock = () => (
         </Link>
       </li>
 
-      <FakeItem mobile tablet desktop />
+      <FakeItem tablet desktop />
       <FakeItem divider mobile />
-      <FakeItem mobile />
 
       <li className={styles.item}>
         <Link href="/tickets">
@@ -61,7 +63,7 @@ export const NavBlock = () => (
         </Link>
       </li>
 
-      <FakeItem desktop />
+      <FakeItem desktop mobile />
     </ul>
   </nav>
 );

--- a/web/components/NavBlock/NavBlock.tsx
+++ b/web/components/NavBlock/NavBlock.tsx
@@ -24,6 +24,7 @@ export const NavBlock = () => (
   <nav className={styles.nav}>
     <ul className={styles.list}>
       <FakeItem mobile />
+
       <li className={styles.item}>
         <Link href="/program">
           <a className={styles.link}>Program</a>

--- a/web/components/NavBlock/NavBlock.tsx
+++ b/web/components/NavBlock/NavBlock.tsx
@@ -2,6 +2,24 @@ import Link from 'next/link';
 import clsx from 'clsx';
 import styles from './NavBlock.module.css';
 
+interface FakeItemProps {
+  divider?: boolean;
+  mobile?: boolean;
+  tablet?: boolean;
+  desktop?: boolean;
+}
+
+const FakeItem = ({ divider, mobile, tablet, desktop }: FakeItemProps) =>
+  <li
+    className={clsx(
+     divider ? styles.divider : styles.fakeItem,
+      mobile && styles.mobile,
+      tablet && styles.tablet,
+      desktop && styles.desktop
+    )}
+    aria-hidden="true"
+  />
+
 export const NavBlock = () => (
   <nav className={styles.nav}>
     <ul className={styles.list}>
@@ -10,94 +28,40 @@ export const NavBlock = () => (
           <a className={styles.link}>Program</a>
         </Link>
       </li>
-      <li
-        className={clsx(
-          styles.fakeItem,
-          styles.mobile,
-          styles.tablet,
-          styles.desktop
-        )}
-        aria-hidden="true"
-      />
-      <li
-        className={clsx(styles.fakeItem, styles.tablet, styles.desktop)}
-        aria-hidden="true"
-      />
-      <li
-        className={clsx(styles.fakeItem, styles.desktop)}
-        aria-hidden="true"
-      />
-      <li
-        className={clsx(
-          styles.divider,
-          styles.mobile,
-          styles.tablet,
-          styles.desktop
-        )}
-        aria-hidden="true"
-      />
-      <li
-        className={clsx(
-          styles.fakeItem,
-          styles.mobile,
-          styles.tablet,
-          styles.desktop
-        )}
-        aria-hidden="true"
-      />
-      <li
-        className={clsx(styles.fakeItem, styles.tablet, styles.desktop)}
-        aria-hidden="true"
-      />
-      <li
-        className={clsx(styles.fakeItem, styles.desktop)}
-        aria-hidden="true"
-      />
+
+      <FakeItem mobile tablet desktop />
+      <FakeItem tablet desktop />
+      <FakeItem desktop />
+      <FakeItem divider mobile tablet desktop />
+      <FakeItem mobile tablet desktop />
+      <FakeItem tablet desktop />
+      <FakeItem desktop />
+
       <li className={styles.item}>
         <Link href="/speakers">
           <a className={styles.link}>Speakers</a>
         </Link>
       </li>
-      <li
-        className={clsx(
-          styles.divider,
-          styles.mobile,
-          styles.tablet,
-          styles.desktop
-        )}
-        aria-hidden="true"
-      />
+
+      <FakeItem divider mobile tablet desktop />
+
       <li className={styles.item}>
         <Link href="/about">
           <a className={styles.link}>About</a>
         </Link>
       </li>
-      <li
-        className={clsx(
-          styles.fakeItem,
-          styles.mobile,
-          styles.tablet,
-          styles.desktop
-        )}
-        aria-hidden="true"
-      />
-      <li
-        className={clsx(styles.divider, styles.mobile)}
-        aria-hidden="true"
-      />
-      <li
-        className={clsx(styles.fakeItem, styles.mobile)}
-        aria-hidden="true"
-      />
+
+      <FakeItem mobile tablet desktop />
+      <FakeItem divider mobile />
+      <FakeItem mobile />
+
       <li className={styles.item}>
         <Link href="/tickets">
           <a className={styles.link}>Early-bird tickets</a>
         </Link>
       </li>
-      <li
-        className={clsx(styles.fakeItem, styles.desktop)}
-        aria-hidden="true"
-      />
+
+      <FakeItem desktop />
     </ul>
   </nav>
 );


### PR DESCRIPTION
# Navblock refactor & rearrange items to match V2 Figma sketch

## Intent

- Fix #29
- Rearrange `<li>` items so the order matches the V2 Figma sketches

## Testing this PR

Triple check that the real and "fake" items render in order matching the specified order in the Figma V2 sketches for all defined viewports.

