### PR TITLE
Fetch correct Sanity content for /home

### DIFF
--- a/web/components/PlaceholderImage/PlaceholderImage.tsx
+++ b/web/components/PlaceholderImage/PlaceholderImage.tsx
@@ -1,0 +1,15 @@
+interface PlaceholderImageProps {
+  className?: string;
+  width: number;
+  height: number;
+}
+
+export const PlaceholderImage = ({ width, height, ...otherProps }: PlaceholderImageProps) =>
+  // eslint-disable-next-line @next/next/no-img-element
+  <img
+    {...otherProps}
+    src={`https://via.placeholder.com/${width}x${height}`}
+    width={width}
+    height={height}
+    alt="Placeholder"
+  />;

--- a/web/components/PlaceholderImage/index.ts
+++ b/web/components/PlaceholderImage/index.ts
@@ -1,0 +1,1 @@
+export { PlaceholderImage as default } from "./PlaceholderImage";

--- a/web/components/SectionBlock/SectionBlock.module.css
+++ b/web/components/SectionBlock/SectionBlock.module.css
@@ -1,9 +1,12 @@
 .sectionBlock {
-  background: #eee;
+  background: var(--color-brand-yellow-light);
   padding: 1rem;
-  margin: 1rem;
-  max-width: 800px;
-  border-radius: 4px;
+  border-radius: 12px;
+  margin: 1rem 1rem var(--spacing-large);
+}
+
+.sectionBlock--gray {
+  background: var(--color-ui-gray-100);
 }
 
 .sectionBlock--noBackground {

--- a/web/components/SectionBlock/SectionBlock.tsx
+++ b/web/components/SectionBlock/SectionBlock.tsx
@@ -4,16 +4,18 @@ import styles from './SectionBlock.module.css';
 
 interface SectionBlockProps extends HTMLAttributes<HTMLDivElement> {
   noBackground?: boolean;
+  gray?: boolean;
 }
 
 export const SectionBlock = forwardRef<HTMLDivElement, SectionBlockProps>(
-  ({ className, noBackground, ...props }: SectionBlockProps, ref) => (
+  ({ className, noBackground, gray, ...props }: SectionBlockProps, ref) => (
     <div
       {...props}
       className={clsx(
         className,
         styles.sectionBlock,
-        noBackground && styles['sectionBlock--noBackground']
+        noBackground && styles['sectionBlock--noBackground'],
+        gray && styles['sectionBlock--gray'],
       )}
       ref={ref}
     />

--- a/web/components/TextBlock/RichText.tsx
+++ b/web/components/TextBlock/RichText.tsx
@@ -1,8 +1,15 @@
 import { TextBlock } from './TextBlock';
 import SectionBlock from '../SectionBlock';
+import Heading from '../Heading';
+import { RichTextSection } from "../../types/RichTextSection";
 
-export const RichText = ({ value }) => (
+interface RichTextProps {
+  value: RichTextSection;
+}
+
+export const RichText = ({ value }: RichTextProps) => (
   <SectionBlock>
+    {value.heading && <Heading type="h2">{value.heading}</Heading>}
     <TextBlock value={value.content} />
   </SectionBlock>
 );

--- a/web/pageResources/home/home.module.css
+++ b/web/pageResources/home/home.module.css
@@ -1,0 +1,3 @@
+.centered {
+  text-align: center;
+}

--- a/web/pages/home.tsx
+++ b/web/pages/home.tsx
@@ -30,9 +30,7 @@ const QUERY = `
     },
     "sponsorship": *[_id == "e629b448-75d1-497a-96be-86e5464ad5b2"],
     "venues": *[_type == "venue"],
-    "frontpage": *[_id == "229058a3-6067-4f8d-b6e1-c59db187d2a8"] {
-      sections[0] 
-    },
+    "broadcastInfo": *[_id == "229058a3-6067-4f8d-b6e1-c59db187d2a8"].sections[0],
     "schedule": *[_id == "5a574e94-5423-4e83-bbf3-3a2f83a5c88b"].sections[0]
   }`;
 
@@ -49,9 +47,7 @@ interface HomeProps {
     sponsors: Sponsor[];
     sponsorship: RichTextSection[];
     venues: Venue[];
-    frontpage: {
-      sections: RichTextSection[]
-    }[];
+    broadcastInfo: RichTextSection[];
     schedule: RichTextSection[];
   };
 }
@@ -68,7 +64,7 @@ const Home = ({
     sponsors,
     sponsorship,
     venues,
-    frontpage,
+    broadcastInfo,
     schedule,
   },
 }: HomeProps) => (
@@ -87,7 +83,7 @@ const Home = ({
     </GridWrapper>
 
     <div className={styles.centered}>
-      <TextBlock value={frontpage[0].sections} />
+      <TextBlock value={broadcastInfo} />
     </div>
 
     <SectionBlock className={styles.centered}>

--- a/web/pages/home.tsx
+++ b/web/pages/home.tsx
@@ -1,12 +1,10 @@
 import Link from 'next/link';
 import client from '../lib/sanity.server';
-import { Person } from '../types/Person';
 import { Section } from '../types/Section';
 import { Sponsor } from '../types/Sponsor';
 import { Venue } from "../types/Venue";
 import SectionBlock from '../components/SectionBlock';
 import Heading from '../components/Heading';
-import Speakers from '../pageResources/home/Speakers';
 import ConferenceUpdatesForm from '../components/ConferenceUpdatesForm';
 import TextBlock from '../components/TextBlock';
 import Sponsors from '../pageResources/home/Sponsors';
@@ -20,11 +18,8 @@ const QUERY = `
     "home": *[_type == "event"][0] {
       name,
       description,
-      tagline,
       startDate,
       endDate,
-      microcopy,
-      promotedSpeakers[]->,
       valueProposition,
     },
     "sponsors": *[_type == "sponsor"] {
@@ -42,14 +37,6 @@ interface HomeProps {
       tagline: string;
       startDate: string;
       endDate: string;
-      microcopy: {
-        _key: string;
-        key: string;
-        action: string;
-        text: string;
-        type: 'link';
-      }[];
-      promotedSpeakers: Person[];
       valueProposition: Section[];
     };
     sponsors: Sponsor[];
@@ -61,12 +48,9 @@ const Home = ({
   data: {
     home: {
       name,
-      tagline,
       startDate,
       endDate,
       description,
-      microcopy,
-      promotedSpeakers,
       valueProposition,
     },
     sponsors,
@@ -83,32 +67,12 @@ const Home = ({
 
     <NavBlock />
 
-    <SectionBlock>
-      {microcopy.map(({ key, action, text }) => (
-        <Link key={key} href={action}>
-          {text}
-        </Link>
-      ))}
-    </SectionBlock>
-
     <GridWrapper>
       <VenueNames venues={venues} />
     </GridWrapper>
 
     <SectionBlock>
       <TextBlock value={valueProposition} />
-    </SectionBlock>
-
-    <SectionBlock>
-      <Speakers speakers={promotedSpeakers} />
-    </SectionBlock>
-
-    <SectionBlock>
-      <Heading type="h2">
-        <Link href="/program">
-          <a>{'Program ->'}</a>
-        </Link>
-      </Heading>
     </SectionBlock>
 
     <SectionBlock>

--- a/web/pages/home.tsx
+++ b/web/pages/home.tsx
@@ -1,8 +1,8 @@
-import Link from 'next/link';
 import client from '../lib/sanity.server';
 import { Section } from '../types/Section';
 import { Sponsor } from '../types/Sponsor';
 import { Venue } from "../types/Venue";
+import { RichTextSection } from "../types/RichTextSection";
 import SectionBlock from '../components/SectionBlock';
 import Heading from '../components/Heading';
 import ConferenceUpdatesForm from '../components/ConferenceUpdatesForm';
@@ -12,6 +12,8 @@ import GridWrapper from '../components/GridWrapper';
 import ConferenceHeader from '../components/ConferenceHeader';
 import NavBlock from '../components/NavBlock';
 import VenueNames from "../components/VenueNames";
+import PlaceholderImage from "../components/PlaceholderImage";
+import styles from "../pageResources/home/home.module.css";
 
 const QUERY = `
   {
@@ -26,7 +28,12 @@ const QUERY = `
       ...,
       sponsorship->
     },
-    "venues": *[_type == "venue"]
+    "sponsorship": *[_id == "e629b448-75d1-497a-96be-86e5464ad5b2"],
+    "venues": *[_type == "venue"],
+    "frontpage": *[_id == "229058a3-6067-4f8d-b6e1-c59db187d2a8"] {
+      sections[0] 
+    },
+    "schedule": *[_id == "5a574e94-5423-4e83-bbf3-3a2f83a5c88b"].sections[0]
   }`;
 
 interface HomeProps {
@@ -40,7 +47,12 @@ interface HomeProps {
       valueProposition: Section[];
     };
     sponsors: Sponsor[];
+    sponsorship: RichTextSection[];
     venues: Venue[];
+    frontpage: {
+      sections: RichTextSection[]
+    }[];
+    schedule: RichTextSection[];
   };
 }
 
@@ -54,7 +66,10 @@ const Home = ({
       valueProposition,
     },
     sponsors,
+    sponsorship,
     venues,
+    frontpage,
+    schedule,
   },
 }: HomeProps) => (
   <GridWrapper>
@@ -71,19 +86,35 @@ const Home = ({
       <VenueNames venues={venues} />
     </GridWrapper>
 
-    <SectionBlock>
-      <TextBlock value={valueProposition} />
+    <div className={styles.centered}>
+      <TextBlock value={frontpage[0].sections} />
+    </div>
+
+    <SectionBlock className={styles.centered}>
+      <PlaceholderImage width={406} height={370}  />
+      <div>
+        <TextBlock value={valueProposition} />
+      </div>
     </SectionBlock>
 
-    <SectionBlock>
-      <Heading type="h2">Sponsors</Heading>
+    <div className={styles.centered}>
+      <TextBlock value={schedule} />
+    </div>
+
+    <div className={styles.centered}>
+      <TextBlock value={sponsorship} />
+    </div>
+
+    <SectionBlock gray>
       <Sponsors sponsors={sponsors} />
-      <Link href="/sponsor">{'Become a Sponsor ->'}</Link>
     </SectionBlock>
 
-    <SectionBlock>
-      <Heading type="h2">Get conference updates</Heading>
-      <ConferenceUpdatesForm />
+    <SectionBlock className={styles.centered}>
+      <PlaceholderImage width={330} height={459} />
+      <div>
+        <Heading type="h2">Get conference updates</Heading>
+        <ConferenceUpdatesForm />
+      </div>
     </SectionBlock>
   </GridWrapper>
 );

--- a/web/types/RichTextSection.ts
+++ b/web/types/RichTextSection.ts
@@ -4,4 +4,5 @@ export type RichTextSection = {
   _key: string;
   _type: 'richText';
   content: Section[];
+  heading?: string;
 };


### PR DESCRIPTION
# Fetch correct Sanity content for /home 

## Intent

As the ["Frontpage February 2022"  Landing Page](http://localhost:3333/desk/page;229058a3-6067-4f8d-b6e1-c59db187d2a8) is lacking content, we continue with our ad-hoc "hardcoded" pages. This PR fetches & renders data for all sections defined by the Figma "Homepage V2" sketch.

## Description

Some of the Sanity queries here query by `_id`. This is quite sketchy and obviously not intended as a final solution, but this type of ad-hoc data gathering will do for now, as the current queries are only there to get the current /home page to look as much like the sketches as possible. As previously discussed, the goal is for Sanity to add the finalized content as Landing Pages, which will make this page obsolete. 

As always, feel entirely free to make any changes to this branch you deem necessary or desirable, @oyvind-stenhaug.

## Testing this PR

This is not so much a "feature" branch as it is a branch I expect to be continuously evolving; given our current schedule, please ping me on Slack if there's questions or concerns that needs addressing. 