### PR TITLE
Style RichText block

### DIFF
--- a/web/components/ConferenceHeader/ConferenceHeader.module.css
+++ b/web/components/ConferenceHeader/ConferenceHeader.module.css
@@ -15,6 +15,11 @@
   row-gap: 24px;
 }
 
+.dates,
+.description {
+  margin: 0;
+}
+
 @media (--medium-up) {
   .root {
     margin: 32px 0 96px;

--- a/web/components/ConferenceHeader/ConferenceHeader.tsx
+++ b/web/components/ConferenceHeader/ConferenceHeader.tsx
@@ -31,7 +31,7 @@ export const ConferenceHeader = ({
         <p className={styles.dates}>
           <DateRange startTimestamp={startDate} endTimestamp={endDate} />
         </p>
-        <p>{description}</p>
+        <p className={styles.description}>{description}</p>
       </div>
     </div>
   );

--- a/web/components/Heading/Heading.module.css
+++ b/web/components/Heading/Heading.module.css
@@ -9,5 +9,13 @@
 }
 
 .h2 {
-  font-size: 1.5rem;
+  font: var(--font-display-xs);
+  margin-bottom: 18px;
+}
+
+@media (--medium-up) {
+  .h2 {
+    font: var(--font-display-base);
+    margin-bottom: 30px;
+  }
 }

--- a/web/components/Nav/Nav.module.css
+++ b/web/components/Nav/Nav.module.css
@@ -16,6 +16,7 @@
 }
 
 .items {
+  margin: 0;
   list-style: none;
   display: flex;
 }

--- a/web/components/NavBlock/NavBlock.module.css
+++ b/web/components/NavBlock/NavBlock.module.css
@@ -6,7 +6,7 @@
   display: flex;
   flex-wrap: wrap;
   list-style: none;
-  margin-right: -8px;
+  margin: 0 -8px 0 0;
   align-items: stretch;
 }
 

--- a/web/components/TextBlock/RichText.module.css
+++ b/web/components/TextBlock/RichText.module.css
@@ -1,0 +1,33 @@
+.container {
+  background: var(--color-brand-yellow-light);
+  padding: 80px 20px;
+  border-radius: 12px;
+  margin: 80px 0;
+}
+
+@media (--medium-up) {
+  .container {
+    padding: 96px 0;
+    margin: 96px 0;
+    display: grid;
+    grid-template-columns: repeat(8, minmax(0, 1fr));
+    column-gap: var(--grid-medium-gutter);
+  }
+
+  .content {
+    grid-column: 2 / span 6;
+  }
+}
+
+@media (--large-up) {
+  .container {
+    padding: 128px 0;
+    margin: 128px 0;
+    grid-template-columns: repeat(12, minmax(0, 1fr));
+    column-gap: var(--grid-gutter);
+  }
+
+  .content {
+    grid-column: 4 / span 6;
+  }
+}

--- a/web/components/TextBlock/RichText.tsx
+++ b/web/components/TextBlock/RichText.tsx
@@ -1,15 +1,20 @@
 import { TextBlock } from './TextBlock';
-import SectionBlock from '../SectionBlock';
+import GridWrapper from '../GridWrapper';
 import Heading from '../Heading';
-import { RichTextSection } from "../../types/RichTextSection";
+import { RichTextSection } from '../../types/RichTextSection';
+import styles from './RichText.module.css';
 
 interface RichTextProps {
   value: RichTextSection;
 }
 
 export const RichText = ({ value }: RichTextProps) => (
-  <SectionBlock>
-    {value.heading && <Heading type="h2">{value.heading}</Heading>}
-    <TextBlock value={value.content} />
-  </SectionBlock>
+  <GridWrapper>
+    <div className={styles.container}>
+      <div className={styles.content}>
+        {value.heading && <Heading type="h2">{value.heading}</Heading>}
+        <TextBlock value={value.content} />
+      </div>
+    </div>
+  </GridWrapper>
 );

--- a/web/pages/home.tsx
+++ b/web/pages/home.tsx
@@ -68,17 +68,17 @@ const Home = ({
     schedule,
   },
 }: HomeProps) => (
-  <GridWrapper>
-    <ConferenceHeader
-      name={name}
-      startDate={startDate}
-      endDate={endDate}
-      description={description}
-    />
-
-    <NavBlock />
-
+  <>
     <GridWrapper>
+      <ConferenceHeader
+        name={name}
+        startDate={startDate}
+        endDate={endDate}
+        description={description}
+      />
+
+      <NavBlock />
+
       <VenueNames venues={venues} />
     </GridWrapper>
 
@@ -112,7 +112,7 @@ const Home = ({
         <ConferenceUpdatesForm />
       </div>
     </SectionBlock>
-  </GridWrapper>
+  </>
 );
 
 export async function getStaticProps() {

--- a/web/styles/globals.css
+++ b/web/styles/globals.css
@@ -42,8 +42,9 @@ body.main-menu-open {
 }
 
 p,
-ul {
-  margin: 0;
+ul,
+ol {
+  margin: 0 0 1em;
   padding: 0;
 }
 

--- a/web/styles/globals.css
+++ b/web/styles/globals.css
@@ -33,10 +33,8 @@ html {
 
 body {
   margin: 0;
-  font-family: Inter, ui-sans-serif, system-ui, -apple-system,
-    BlinkMacSystemFont, Segoe UI, Roboto, Helvetica Neue, Arial, Noto Sans,
-    sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol,
-    Noto Color Emoji;
+  font: var(--font-body-base-medium);
+  letter-spacing: var(--letter-spacing-body-base);
 }
 
 body.main-menu-open {

--- a/web/styles/globals.css
+++ b/web/styles/globals.css
@@ -49,6 +49,7 @@ ol {
 }
 
 a {
+  color: var(--color-sanity-blue);
   text-decoration: underline;
 }
 

--- a/web/styles/variables.css
+++ b/web/styles/variables.css
@@ -4,6 +4,7 @@
   --color-brand-white: #ffffff;
   --color-brand-yellow: #fff17e;
   --color-brand-yellow-light: #fff8e4;
+  --color-sanity-blue: #2962ff;
   --color-ui-gray-600: #6f6d6a;
   --color-ui-gray-500: #a0a09c;
   --color-ui-gray-300: #deddd9;

--- a/web/styles/variables.css
+++ b/web/styles/variables.css
@@ -16,6 +16,7 @@
   --font-display-lg: 700 64px/64px sans-serif; /* Web font not received yet */
   --font-display-sm: 700 32px/35px sans-serif; /* Web font not received yet */
   --font-display-xl: 700 72px/69.12px sans-serif; /* Web font not received yet */
+  --font-display-xs: 700 28px/35px sans-serif; /* Web font not received yet */
   --font-ui-sm-medium: 500 16px/22px 'Inter', sans-serif;
   --font-ui-xxl-medium: 500 40px/56px 'Inter', sans-serif;
   --grid-gutter: 40px;


### PR DESCRIPTION
# Style RichText block

## Intent

Add some basic/sample styling of the RichText block

## Description

The Figma sketches here have more variation than the content model supports, as far as I can tell, so I just picked something for now. Might be adjusted later based on feedback/what happens in Sanity.

I wasn't sure how to keep using `SectionBlock` since the various sections look rather different in terms of grid/padding/margin etc. So I assumed it was still just intended to be just a temporary thing, and added something RichText-specific instead.

## Testing this PR
Open /home, scroll down and check that the yellow text boxes without (gray) images in them look OK