### PR TITLE
ConferenceUpdatesForm frontend

### DIFF
--- a/web/components/ConferenceUpdatesForm/ConferenceUpdatesForm.module.css
+++ b/web/components/ConferenceUpdatesForm/ConferenceUpdatesForm.module.css
@@ -1,22 +1,94 @@
 .container {
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  text-align: center;
+  padding: 48px 24px;
+  background: var(--color-brand-yellow-light);
+  margin: 80px 0;
+}
+
+.image {
+  display: none;
+}
+
+.formContents {
+  position: relative;
 }
 
 .emailInput {
-  height: 1rem;
-  padding: 1rem;
-  margin-right: 0.5rem;
+  border: none;
+  /* Design sketch has left padding 24px but then the placeholder won't fit */
+  padding: 19.5px 56px 19.5px 10px;
+  width: 100%;
 }
 
 .submitButton {
-  background: #00a0d2;
-  color: white;
-  padding: 1rem;
-  border: 1px solid blue;
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  bottom: 8px;
+  border: none;
+  background: var(--color-brand-orange);
+  border-radius: 4px;
+  min-width: 48px;
+  cursor: pointer;
+}
+
+.submitButton:hover {
+  background: var(--color-brand-yellow);
+}
+
+.submitButton:active {
+  background: var(--color-brand-yellow-light);
 }
 
 .emailParagraph {
-  padding-top: 1rem;
+  margin: 24px 0 0;
+  font: var(--font-ui-sm-medium);
+  letter-spacing: var(--letter-spacing-ui-sm);
+}
+
+@media (--small-up) {
+  .emailInput {
+    padding-left: 24px;
+  }
+}
+
+@media (--medium-up) {
+  .container {
+    padding: 64px 48px;
+    margin: 96px 0;
+  }
+
+  .formContents {
+    /* Simplification due to time constraints. Sketch has it cover exactly 4
+     * columns, but on desktop it doesn't match the grid columns anyway, so it
+     * seems somewhat arbitrary.
+     */
+    max-width: 19em;
+    margin: 0 auto;
+  }
+}
+
+@media (--large-up) {
+  .container {
+    text-align: left;
+    padding: 116px 0;
+    margin: 128px 0;
+    display: grid;
+    grid-template-columns: repeat(12, minmax(0, 1fr));
+    align-items: center;
+  }
+
+  .image {
+    display: block;
+    grid-column: 2 / span 4;
+  }
+
+  .mainContents {
+    grid-column: 7 / span 4;
+  }
+
+  .formContents {
+    max-width: 100%;
+    margin: 0;
+  }
 }

--- a/web/components/ConferenceUpdatesForm/ConferenceUpdatesForm.tsx
+++ b/web/components/ConferenceUpdatesForm/ConferenceUpdatesForm.tsx
@@ -1,37 +1,46 @@
+import GridWrapper from '../GridWrapper';
+import Heading from '../Heading';
 import Paragraph from '../Paragraph';
 import PlaceholderImage from '../PlaceholderImage';
-import Heading from '../Heading';
 import styles from './ConferenceUpdatesForm.module.css';
 
 export const ConferenceUpdatesForm = () => (
-  <div className={styles.container}>
-    <PlaceholderImage width={330} height={459} />
+  <GridWrapper>
+    <article className={styles.container}>
+      <PlaceholderImage width={330} height={459} className={styles.image} />
 
-    <div>
-      <Heading type="h2">Get conference updates</Heading>
-      <form
-        action="https://sanity.us3.list-manage.com/subscribe/post"
-        method="POST"
-      >
-        <input type="hidden" name="u" value="3e99a07b5e03ed5b07a234a57" />
-        <input type="hidden" name="id" value="cca563332b" />
-        <div>
-          <input
-            id="mce-EMAIL"
-            name="EMAIL"
-            type="email"
-            placeholder="Email address"
-            required
-            className={styles.emailInput}
-          />
-          <button type="submit" className={styles.submitButton}>
-            Sign up
-          </button>
-        </div>
-      </form>
-      <Paragraph className={styles.emailParagraph}>
-        We&#39;ll only send you updates about the conference
-      </Paragraph>
-    </div>
-  </div>
+      <div className={styles.mainContents}>
+        <Heading type="h2">Get conference updates</Heading>
+        <form
+          action="https://sanity.us3.list-manage.com/subscribe/post"
+          method="POST"
+          className={styles.form}
+        >
+          <div className={styles.formContents}>
+            <input type="hidden" name="u" value="3e99a07b5e03ed5b07a234a57" />
+            <input type="hidden" name="id" value="cca563332b" />
+            <input
+              id="mce-EMAIL"
+              name="EMAIL"
+              type="email"
+              placeholder="Your email address"
+              aria-label="Your email address"
+              required
+              className={styles.emailInput}
+            />
+            <button
+              type="submit"
+              className={styles.submitButton}
+              aria-label="Sign up"
+            >
+              -&gt;
+            </button>
+          </div>
+        </form>
+        <p className={styles.emailParagraph}>
+          We&#39;ll only send you updates about the conference
+        </p>
+      </div>
+    </article>
+  </GridWrapper>
 );

--- a/web/pages/home.tsx
+++ b/web/pages/home.tsx
@@ -99,9 +99,7 @@ const Home = ({
       <Sponsors sponsors={sponsors} />
     </SectionBlock>
 
-    <SectionBlock className={styles.centered}>
-      <ConferenceUpdatesForm />
-    </SectionBlock>
+    <ConferenceUpdatesForm />
   </>
 );
 

--- a/web/styles/globals.css
+++ b/web/styles/globals.css
@@ -53,6 +53,11 @@ a {
   text-decoration: underline;
 }
 
+button,
+input {
+  font: inherit;
+}
+
 @media (--medium-up) {
   body.main-menu-open {
     overflow: auto;

--- a/web/styles/media.css
+++ b/web/styles/media.css
@@ -1,2 +1,3 @@
+@custom-media --small-up (min-width: 390px);
 @custom-media --medium-up (min-width: 768px);
 @custom-media --large-up (min-width: 1025px);


### PR DESCRIPTION
# ConferenceUpdatesForm frontend

## Intent

Update markup and CSS for ConferenceUpdatesForm so it more-or-less looks like the Figma sketch

## Description

Not much to say here. Markup is mostly unchanged aside from the introduction of the `GridWrapper` and some ARIA labels.

Would be a bit nicer to keep the original button label and only add the arrow via CSS, but the aria-label was faster.

## Testing this PR
1. Open [/home](https://structured-content-2022-web-git-conference-updates-form-92b5da.sanity.build/home)
2. Scroll down almost to the bottom
3. Verify that the "Get conference updates" section above the gray footer looks OK in various screen sizes