### PR TITLE
"Hero" frontend

### DIFF
--- a/web/components/Heading/Heading.module.css
+++ b/web/components/Heading/Heading.module.css
@@ -1,11 +1,5 @@
 .heading {
-  font-weight: 700;
-  line-height: 1.2;
   margin: 0;
-}
-
-.h1 {
-  font-size: 2.5rem;
 }
 
 .h2 {

--- a/web/components/Hero/Hero.module.css
+++ b/web/components/Hero/Hero.module.css
@@ -1,0 +1,27 @@
+.container {
+  background: var(--color-brand-yellow-light);
+  text-align: center;
+  padding: 40px 0 80px;
+}
+
+@media (--medium-up) {
+  .container {
+    padding: 96px 0;
+  }
+}
+
+@media (--large-up) {
+  .container {
+    padding: 128px 0;
+  }
+
+  .headingContainer {
+    display: grid;
+    grid-template-columns: repeat(12, minmax(0, 1fr));
+    column-gap: var(--grid-gutter);
+  }
+
+  .heading {
+    grid-column: 3 / span 8;
+  }
+}

--- a/web/components/Hero/Hero.module.css
+++ b/web/components/Hero/Hero.module.css
@@ -4,9 +4,17 @@
   padding: 40px 0 80px;
 }
 
+.cta {
+  margin-top: 32px;
+}
+
 @media (--medium-up) {
   .container {
     padding: 96px 0;
+  }
+
+  .cta {
+    margin-top: 40px;
   }
 }
 
@@ -21,7 +29,8 @@
     column-gap: var(--grid-gutter);
   }
 
-  .heading {
+  .heading,
+  .cta {
     grid-column: 3 / span 8;
   }
 }

--- a/web/components/Hero/Hero.tsx
+++ b/web/components/Hero/Hero.tsx
@@ -1,0 +1,16 @@
+import GridWrapper from '../GridWrapper';
+import styles from './Hero.module.css';
+
+interface HeroProps {
+  heading: string;
+}
+
+export const Hero = ({ heading }: HeroProps) => (
+  <div className={styles.container}>
+    <GridWrapper>
+      <div className={styles.headingContainer}>
+        <h1 className={styles.heading}>{heading}</h1>
+      </div>
+    </GridWrapper>
+  </div>
+);

--- a/web/components/Hero/Hero.tsx
+++ b/web/components/Hero/Hero.tsx
@@ -1,15 +1,25 @@
+import ButtonLink from '../ButtonLink';
 import GridWrapper from '../GridWrapper';
 import styles from './Hero.module.css';
 
 interface HeroProps {
   heading: string;
+  cta?: {
+    url: string;
+    text: string;
+  };
 }
 
-export const Hero = ({ heading }: HeroProps) => (
+export const Hero = ({ heading, cta }: HeroProps) => (
   <div className={styles.container}>
     <GridWrapper>
       <div className={styles.headingContainer}>
         <h1 className={styles.heading}>{heading}</h1>
+        {cta && (
+          <div className={styles.cta}>
+            <ButtonLink text={cta.text} url={cta.url} />
+          </div>
+        )}
       </div>
     </GridWrapper>
   </div>

--- a/web/components/Hero/index.ts
+++ b/web/components/Hero/index.ts
@@ -1,0 +1,1 @@
+export { Hero as default } from './Hero';

--- a/web/pages/[[...slug]].tsx
+++ b/web/pages/[[...slug]].tsx
@@ -1,10 +1,8 @@
 import { groq } from 'next-sanity';
 import client from '../lib/sanity.server';
 import { Section } from '../types/Section';
-import SectionBlock from '../components/SectionBlock';
+import Hero from '../components/Hero';
 import TextBlock from '../components/TextBlock';
-import Heading from '../components/Heading';
-import GridWrapper from '../components/GridWrapper';
 
 const QUERY = groq`
   {
@@ -39,12 +37,10 @@ const Route = ({
   },
 }: RouteProps) => {
   return (
-    <GridWrapper>
-      <SectionBlock>
-        <Heading>{name}</Heading>
-      </SectionBlock>
+    <>
+      <Hero heading={name} />
       <TextBlock value={sections} />
-    </GridWrapper>
+    </>
   );
 };
 

--- a/web/pages/about.tsx
+++ b/web/pages/about.tsx
@@ -2,8 +2,8 @@ import { groq } from 'next-sanity';
 import client from '../lib/sanity.server';
 import { RichTextSection } from '../types/RichTextSection';
 import { Venue } from '../types/Venue';
+import Hero from '../components/Hero';
 import SectionBlock from '../components/SectionBlock';
-import Heading from '../components/Heading';
 import ConferenceUpdatesForm from '../components/ConferenceUpdatesForm';
 import TextBlock from '../components/TextBlock';
 import GridWrapper from '../components/GridWrapper';
@@ -55,17 +55,17 @@ const About = ({
     sponsorship: { sections: sponsorshipSections },
   },
 }: AboutProps) => (
-  <GridWrapper>
-    <SectionBlock>
-      <Heading>{name}</Heading>
-    </SectionBlock>
+  <>
+    <Hero heading={name} />
 
     <TextBlock value={sections} />
 
-    <SectionBlock>
-      <VenueNames venues={venues} />
-      <TextBlock value={conferenceLocationSections} />
-    </SectionBlock>
+    <GridWrapper>
+      <SectionBlock>
+        <VenueNames venues={venues} />
+        <TextBlock value={conferenceLocationSections} />
+      </SectionBlock>
+    </GridWrapper>
 
     <TextBlock value={codeOfConductSections} />
 
@@ -74,7 +74,7 @@ const About = ({
     <SectionBlock>
       <ConferenceUpdatesForm />
     </SectionBlock>
-  </GridWrapper>
+  </>
 );
 
 export async function getStaticProps() {

--- a/web/pages/program.tsx
+++ b/web/pages/program.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 import { Session } from '../types/Session';
 import client from '../lib/sanity.server';
+import Hero from '../components/Hero';
 import SectionBlock from '../components/SectionBlock';
 import Heading from '../components/Heading';
 import Sessions from '../components/Sessions';
@@ -38,7 +39,8 @@ const Program = ({
     program: { name, sections },
   },
 }: ProgramProps) => (
-  <GridWrapper>
+  <>
+    <Hero heading={name} cta={{ url: '#', text: 'Registration' }} />
     <SectionBlock>
       <Heading>{name}</Heading>
       <Link href="#">Registration</Link>
@@ -48,12 +50,14 @@ const Program = ({
       <TextBlock value={sections} />
     </SectionBlock>
 
-    <Sessions sessions={sessions} />
+    <GridWrapper>
+      <Sessions sessions={sessions} />
 
-    <SectionBlock noBackground>
-      <Link href="#">Registration</Link>
-    </SectionBlock>
-  </GridWrapper>
+      <SectionBlock noBackground>
+        <Link href="#">Registration</Link>
+      </SectionBlock>
+    </GridWrapper>
+  </>
 );
 
 export async function getStaticProps() {

--- a/web/styles/globals.css
+++ b/web/styles/globals.css
@@ -43,6 +43,7 @@ body.main-menu-open {
 
 h1 {
   font: var(--font-display-base);
+  margin: 0;
 }
 
 p,

--- a/web/styles/globals.css
+++ b/web/styles/globals.css
@@ -41,6 +41,10 @@ body.main-menu-open {
   overflow: hidden;
 }
 
+h1 {
+  font: var(--font-display-base);
+}
+
 p,
 ul,
 ol {
@@ -56,5 +60,15 @@ a {
 @media (--medium-up) {
   body.main-menu-open {
     overflow: auto;
+  }
+
+  h1 {
+    font: var(--font-display-xl);
+  }
+}
+
+@media (--large-up) {
+  h1 {
+    font: var(--font-display-2xl);
   }
 }

--- a/web/styles/variables.css
+++ b/web/styles/variables.css
@@ -12,6 +12,7 @@
   --font-body-base-medium: 500 18px/25px 'Inter', sans-serif;
   --font-body-large-medium: 500 20px/30px 'Inter', sans-serif;
   --font-body-xl-medium: 500 24px/33px 'Inter', sans-serif;
+  --font-display-2xl: 700 96px/92.16px sans-serif; /* Web font not received yet */
   --font-display-base: 700 40px/39px sans-serif; /* Web font not received yet */
   --font-display-lg: 700 64px/64px sans-serif; /* Web font not received yet */
   --font-display-sm: 700 32px/35px sans-serif; /* Web font not received yet */


### PR DESCRIPTION
# "Hero" frontend

## Intent

Implement basic styling for the article "Hero", and start using it for the pages that have approved design

## Description

Here I've skipped the other pages just in case that helps reduce merge conflicts with what you're working on.

Approach is limited to styling whatever's there at the moment. Not sure if we'll keep the CTA since the Figma sketch for Program looks like it has a title + an intro ("ingress") + a per-page CTA, whereas the Sanity contents just have title and puts the "intro"-ish text as a regular richText section.

## Testing this PR
1. Open https://structured-content-2022-web-git-hero-frontend.sanity.build/about, verify that the topmost part with the page heading looks OK-ish (though the narrow display font isn't available yet, so the text will look pretty huge compared to the Figma sketch)
2. Open https://structured-content-2022-web-git-hero-frontend.sanity.build/program, repeat
3. Open https://structured-content-2022-web-git-hero-frontend.sanity.build/venues, repeat