### PR TITLE
Remove VenueNames links

### DIFF
--- a/web/components/VenueNames/VenueNames.tsx
+++ b/web/components/VenueNames/VenueNames.tsx
@@ -1,5 +1,4 @@
 import { Venue } from '../../types/Venue';
-import { getEntityPath } from '../../util/entityPaths';
 import styles from './VenueNames.module.css';
 
 interface VenueNamesProps {
@@ -10,9 +9,7 @@ export const VenueNames = ({ venues }: VenueNamesProps) => (
   <ul className={styles.venues}>
     {venues.map((venue) => (
       <li key={venue.name} className={styles.venue}>
-        <a href={getEntityPath(venue)} className={styles.link}>
-          {venue.name}
-        </a>
+        {venue.name}
       </li>
     ))}
   </ul>


### PR DESCRIPTION
# Remove VenueNames links

## Intent

Temporarily remove the link markup from VenueNames, because the pages won't be ready for launch. We can re-link when they are ready.

## Description

Emilie defined the venue pages out-of-scope for the initial version, in a [thread in Figma](https://www.figma.com/file/XjAvJKsLpxYJSc8QDWK81j?node-id=1:65#154083263). There was either a bit of back-and-forth on this earlier on, or just a misunderstanding on my part (it was mentioned in a video meeting/standup).

## Testing this PR

1. Open https://structured-content-2022-web-git-remove-venue-names-links.sanity.build/home
2. Scroll down to the location names (currently: "Oslo HQ", "New York" etc) below the orange navigation boxes
3. Verify that the names are not clickable (i.e. it's just text, not links)