### PR TITLE
Mute RichText section styling

### DIFF
--- a/web/components/TextBlock/RichText.module.css
+++ b/web/components/TextBlock/RichText.module.css
@@ -1,17 +1,23 @@
 .container {
+  margin: 80px 0;
+}
+
+.container.background {
   background: var(--color-brand-yellow-light);
   padding: 80px 20px;
   border-radius: 12px;
-  margin: 80px 0;
 }
 
 @media (--medium-up) {
   .container {
-    padding: 96px 0;
     margin: 96px 0;
     display: grid;
     grid-template-columns: repeat(8, minmax(0, 1fr));
     column-gap: var(--grid-medium-gutter);
+  }
+
+  .container.background {
+    padding: 96px 0;
   }
 
   .content {
@@ -21,10 +27,13 @@
 
 @media (--large-up) {
   .container {
-    padding: 128px 0;
     margin: 128px 0;
     grid-template-columns: repeat(12, minmax(0, 1fr));
     column-gap: var(--grid-gutter);
+  }
+
+  .container.background {
+    padding: 128px 0;
   }
 
   .content {

--- a/web/components/TextBlock/RichText.module.css
+++ b/web/components/TextBlock/RichText.module.css
@@ -8,6 +8,10 @@
   border-radius: 12px;
 }
 
+.subHeading {
+  font: var(--font-body-base-medium);
+}
+
 @media (--medium-up) {
   .container {
     margin: 96px 0;

--- a/web/components/TextBlock/RichText.tsx
+++ b/web/components/TextBlock/RichText.tsx
@@ -16,7 +16,9 @@ export const RichText = ({ value, background }: RichTextProps) => (
       <div className={styles.content}>
         <hgroup>
           {value.heading && <Heading type="h2">{value.heading}</Heading>}
-          {value.subheading && <h3 className={styles.subHeading}>{value.subheading}</h3>}
+          {value.subheading && (
+            <h3 className={styles.subHeading}>{value.subheading}</h3>
+          )}
         </hgroup>
         <TextBlock value={value.content} />
       </div>

--- a/web/components/TextBlock/RichText.tsx
+++ b/web/components/TextBlock/RichText.tsx
@@ -7,6 +7,10 @@ import styles from './RichText.module.css';
 
 interface RichTextProps {
   value: RichTextSection;
+  /* TODO: This is currently unused. Investigate if caller can set it based on
+   * some rules related to the section's index or similar (e.g. "the nth
+   * RichText section should have its background set")
+   */
   background?: boolean;
 }
 

--- a/web/components/TextBlock/RichText.tsx
+++ b/web/components/TextBlock/RichText.tsx
@@ -14,8 +14,10 @@ export const RichText = ({ value, background }: RichTextProps) => (
   <GridWrapper>
     <div className={clsx(styles.container, background && styles.background)}>
       <div className={styles.content}>
-        {value.heading && <Heading type="h2">{value.heading}</Heading>}
-        {value.subheading && <Heading type="h3">{value.subheading}</Heading>}
+        <hgroup>
+          {value.heading && <Heading type="h2">{value.heading}</Heading>}
+          {value.subheading && <h3 className={styles.subHeading}>{value.subheading}</h3>}
+        </hgroup>
         <TextBlock value={value.content} />
       </div>
     </div>

--- a/web/components/TextBlock/RichText.tsx
+++ b/web/components/TextBlock/RichText.tsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx';
 import { TextBlock } from './TextBlock';
 import GridWrapper from '../GridWrapper';
 import Heading from '../Heading';
@@ -6,11 +7,12 @@ import styles from './RichText.module.css';
 
 interface RichTextProps {
   value: RichTextSection;
+  background?: boolean;
 }
 
-export const RichText = ({ value }: RichTextProps) => (
+export const RichText = ({ value, background }: RichTextProps) => (
   <GridWrapper>
-    <div className={styles.container}>
+    <div className={clsx(styles.container, background && styles.background)}>
       <div className={styles.content}>
         {value.heading && <Heading type="h2">{value.heading}</Heading>}
         {value.subheading && <Heading type="h3">{value.subheading}</Heading>}

--- a/web/styles/globals.css
+++ b/web/styles/globals.css
@@ -33,7 +33,7 @@ html {
 
 body {
   margin: 0;
-  font: var(--font-body-base-medium);
+  font: var(--font-body-base);
   letter-spacing: var(--letter-spacing-body-base);
 }
 

--- a/web/styles/variables.css
+++ b/web/styles/variables.css
@@ -9,6 +9,7 @@
   --color-ui-gray-500: #a0a09c;
   --color-ui-gray-300: #deddd9;
   --color-ui-gray-100: #f4f3ef;
+  --font-body-base: 400 18px/25px 'Inter', sans-serif;
   --font-body-base-medium: 500 18px/25px 'Inter', sans-serif;
   --font-body-large-medium: 500 20px/30px 'Inter', sans-serif;
   --font-body-xl-medium: 500 24px/33px 'Inter', sans-serif;


### PR DESCRIPTION
# Mute RichText section styling

## Intent

Currently the RichText section always has a yellow box. This is a bit too much as a default, since we don't currently have a logic to determine which ones should be yellow (and it turned out no pragmatic setting for it would be added in the Sanity data model). This PR tries to "dial it back" a bit.

## Description

Theoretically, the component still supports a yellow box via an optional prop (so the styling is kept). But so far this variation isn't used.

Also trying out a regular-weight font for body text like in the About/etc sketches, instead of having medium bold everywhere like on the frontpage sketch. Again just to try having a more "normal" default.

And finally some experimental styling for the `subHeading`.

## Testing this PR
1. Open the [front page](https://structured-content-2022-web-git-mute-rich-text-section-styling.sanity.build/)
2. Verify that the "We will be broadcasting" + "Schedule" + "Sponsor Structured Content 2022" sections look OK (aside from the oddly placed "Get sponsorship information" button)