### PR TITLE
Style TextAndImage section

### DIFF
--- a/web/components/TextBlock/TextAndImage.module.css
+++ b/web/components/TextBlock/TextAndImage.module.css
@@ -1,4 +1,8 @@
 .container {
+  background: var(--color-brand-yellow-light);
+}
+
+.contents {
   display: flex;
   flex-direction: row;
   align-items: center;

--- a/web/components/TextBlock/TextAndImage.module.css
+++ b/web/components/TextBlock/TextAndImage.module.css
@@ -1,15 +1,57 @@
 .container {
   background: var(--color-brand-yellow-light);
+  padding: 64px 0;
 }
 
-.contents {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  justify-content: center;
+.imageContainer {
+  margin-bottom: 60px;
+  text-align: center;
 }
 
 .image {
-  width: 200px;
-  height: 200px;
+  vertical-align: top;
+  max-width: 100%;
+}
+
+.tagline {
+  font: var(--font-body-base-medium);
+  margin: 0 0 1em;
+}
+
+@media (--medium-up) {
+  .container {
+    padding: 96px 0;
+  }
+
+  .contents {
+    display: grid;
+    grid-template-columns: repeat(8, minmax(0, 1fr));
+    column-gap: var(--grid-medium-gutter);
+    align-items: center;
+  }
+
+  .imageContainer {
+    margin-bottom: 96px;
+  }
+
+  .imageContainer,
+  .text {
+    grid-column: 2 / span 6;
+  }
+}
+
+@media (--large-up) {
+  .contents {
+    grid-template-columns: repeat(12, minmax(0, 1fr));
+    column-gap: var(--grid-gutter);
+  }
+
+  .imageContainer {
+    margin-bottom: 0;
+    grid-column: 2 / span 4;
+  }
+
+  .text {
+    grid-column: 7 / span 5;
+  }
 }

--- a/web/components/TextBlock/TextAndImage.tsx
+++ b/web/components/TextBlock/TextAndImage.tsx
@@ -1,4 +1,5 @@
 import { imageUrlFor } from '../../lib/sanity';
+import GridWrapper from '../GridWrapper';
 import Heading from '../Heading';
 import { Block } from './Block';
 import styles from './TextAndImage.module.css';
@@ -11,17 +12,19 @@ interface TextAndImageProps {
 }
 
 export const TextAndImage = ({ value: { image, tagline, text, title } }) => (
-  <div className={styles.container}>
-    <div className={styles.image}>
-      {/* eslint-disable-next-line @next/next/no-img-element */}
-      <img src={imageUrlFor(image).ignoreImageParams().url()} alt="" />
-    </div>
-    <div>
-      <Heading type="h2">{title}</Heading>
-      <Heading type="h3">{tagline}</Heading>
-      {text.map((value) => (
-        <Block key={value._key} value={value} />
-      ))}
-    </div>
-  </div>
+  <section className={styles.container}>
+    <GridWrapper>
+      <div className={styles.contents}>
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img src={imageUrlFor(image).ignoreImageParams().url()} alt="" className={styles.image} />
+        <div>
+          <Heading type="h2">{title}</Heading>
+          <Heading type="h3">{tagline}</Heading>
+          {text.map((value) => (
+            <Block key={value._key} value={value} />
+          ))}
+        </div>
+      </div>
+    </GridWrapper>
+  </section>
 );

--- a/web/components/TextBlock/TextAndImage.tsx
+++ b/web/components/TextBlock/TextAndImage.tsx
@@ -15,11 +15,23 @@ export const TextAndImage = ({ value: { image, tagline, text, title } }) => (
   <section className={styles.container}>
     <GridWrapper>
       <div className={styles.contents}>
-        {/* eslint-disable-next-line @next/next/no-img-element */}
-        <img src={imageUrlFor(image).ignoreImageParams().url()} alt="" className={styles.image} />
-        <div>
-          <Heading type="h2">{title}</Heading>
-          <Heading type="h3">{tagline}</Heading>
+        <div className={styles.imageContainer}>
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={imageUrlFor(image).ignoreImageParams().url()}
+            alt=""
+            className={styles.image}
+          />
+        </div>
+        <div className={styles.text}>
+          {title && (
+            <hgroup>
+              <Heading type="h2">{title}</Heading>
+              {tagline && (
+                <h3 className={styles.tagline}>{tagline}</h3>
+              )}
+            </hgroup>
+          )}
           {text.map((value) => (
             <Block key={value._key} value={value} />
           ))}

--- a/web/components/TextBlock/TextAndImage.tsx
+++ b/web/components/TextBlock/TextAndImage.tsx
@@ -27,9 +27,7 @@ export const TextAndImage = ({ value: { image, tagline, text, title } }) => (
           {title && (
             <hgroup>
               <Heading type="h2">{title}</Heading>
-              {tagline && (
-                <h3 className={styles.tagline}>{tagline}</h3>
-              )}
+              {tagline && <h3 className={styles.tagline}>{tagline}</h3>}
             </hgroup>
           )}
           {text.map((value) => (


### PR DESCRIPTION
# Style TextAndImage section

## Intent

Tweak markup for, and add styling to, the TextAndImage component, based on Figma front page sketch

## Description

More or less based on Figma, but using the base font weight for normal body text, which is currently 400 (= Regular).

I left the `Block` map as-is, though it looks like it spits out `span`s and not paragraphs, I'm not sure if that was intended.

The image should really have `width` and `height` attributes for CLS-related purposes. This is https://github.com/sanity-io/structured-content-2022/issues/40

## Testing this PR

1. Open the [front page](https://structured-content-2022-web-git-style-text-and-image-section.sanity.build/)
2. Scroll down to the section with the "Content / Collaboration / Community" image, and verify that it looks OK