### PR TITLE
Footer links from sanity

### DIFF
--- a/web/components/Footer/Footer.tsx
+++ b/web/components/Footer/Footer.tsx
@@ -13,6 +13,7 @@ interface FooterProps {
   links: {
     name: string;
     slug: Slug;
+    _id: string;
   }[];
 }
 
@@ -72,8 +73,8 @@ export const Footer = ({ links }: FooterProps) => (
       <ul className={styles.links}>
         {links
           ?.filter(({ slug }) => slug.current)
-          .map(({ name, slug }) => (
-            <li key={name} className={styles.linksItem}>
+          .map(({ name, slug, _id }) => (
+            <li key={_id} className={styles.linksItem}>
               <Link href={`/${slug.current}`}>
                 <a className={styles.linksItemLink}>{name}</a>
               </Link>

--- a/web/components/Footer/Footer.tsx
+++ b/web/components/Footer/Footer.tsx
@@ -7,8 +7,16 @@ import linkedinLogo from '../../images/linkedin_logo_black.svg';
 import GridWrapper from '../GridWrapper';
 import Paragraph from '../Paragraph';
 import styles from './Footer.module.css';
+import { Slug } from "../../types/Slug";
 
-export const Footer = () => (
+interface FooterProps {
+  links: {
+    name: string;
+    slug: Slug;
+  }[];
+}
+
+export const Footer = ({ links }: FooterProps) => (
   <footer className={styles.container}>
     <GridWrapper>
       <div className={styles.logoContainer}>
@@ -62,26 +70,15 @@ export const Footer = () => (
 
     <GridWrapper>
       <ul className={styles.links}>
-        <li className={styles.linksItem}>
-          <Link href="/code-of-conduct">
-            <a className={styles.linksItemLink}>Code of conduct</a>
-          </Link>
-        </li>
-        <li className={styles.linksItem}>
-          <Link href="/privacy-policy">
-            <a className={styles.linksItemLink}>Privacy policy</a>
-          </Link>
-        </li>
-        <li className={styles.linksItem}>
-          <Link href="/contact">
-            <a className={styles.linksItemLink}>Contact</a>
-          </Link>
-        </li>
-        <li className={styles.linksItem}>
-          <Link href="/venues">
-            <a className={styles.linksItemLink}>Venues</a>
-          </Link>
-        </li>
+        {links
+          ?.filter(({ slug }) => slug.current)
+          .map(({ name, slug }) => (
+          <li key={name} className={styles.linksItem}>
+            <Link href={`/${slug.current}`}>
+              <a className={styles.linksItemLink}>{name}</a>
+            </Link>
+          </li>
+        ))}
       </ul>
     </GridWrapper>
   </footer>

--- a/web/components/Footer/Footer.tsx
+++ b/web/components/Footer/Footer.tsx
@@ -7,7 +7,7 @@ import linkedinLogo from '../../images/linkedin_logo_black.svg';
 import GridWrapper from '../GridWrapper';
 import Paragraph from '../Paragraph';
 import styles from './Footer.module.css';
-import { Slug } from "../../types/Slug";
+import { Slug } from '../../types/Slug';
 
 interface FooterProps {
   links: {
@@ -73,12 +73,12 @@ export const Footer = ({ links }: FooterProps) => (
         {links
           ?.filter(({ slug }) => slug.current)
           .map(({ name, slug }) => (
-          <li key={name} className={styles.linksItem}>
-            <Link href={`/${slug.current}`}>
-              <a className={styles.linksItemLink}>{name}</a>
-            </Link>
-          </li>
-        ))}
+            <li key={name} className={styles.linksItem}>
+              <Link href={`/${slug.current}`}>
+                <a className={styles.linksItemLink}>{name}</a>
+              </Link>
+            </li>
+          ))}
       </ul>
     </GridWrapper>
   </footer>

--- a/web/pages/[[...slug]].tsx
+++ b/web/pages/[[...slug]].tsx
@@ -6,8 +6,8 @@ import TextBlock from '../components/TextBlock';
 import GridWrapper from '../components/GridWrapper';
 import ConferenceHeader from '../components/ConferenceHeader';
 import NavBlock from '../components/NavBlock';
-import Footer from "../components/Footer";
-import { Slug } from "../types/Slug";
+import Footer from '../components/Footer';
+import { Slug } from '../types/Slug';
 
 const QUERY = groq`
   {
@@ -97,20 +97,20 @@ const Route = ({
 }: RouteProps) => (
   <>
     <main>
-    {slug === '/' ? (
-      <GridWrapper>
-        <ConferenceHeader
-          name={homeName}
-          startDate={startDate}
-          endDate={endDate}
-          description={description}
-        />
-        <NavBlock />
-      </GridWrapper>
-    ) : (
-      <Hero heading={name} />
-    )}
-    <TextBlock value={sections} />
+      {slug === '/' ? (
+        <GridWrapper>
+          <ConferenceHeader
+            name={homeName}
+            startDate={startDate}
+            endDate={endDate}
+            description={description}
+          />
+          <NavBlock />
+        </GridWrapper>
+      ) : (
+        <Hero heading={name} />
+      )}
+      <TextBlock value={sections} />
     </main>
     <Footer links={footer.links} />
   </>

--- a/web/pages/[[...slug]].tsx
+++ b/web/pages/[[...slug]].tsx
@@ -57,6 +57,7 @@ const QUERY = groq`
       "links": tree[].value.reference-> {
         "name": seo.title,
         slug,
+        _id,
       }
     },
   }`;
@@ -79,6 +80,7 @@ interface RouteProps {
       links: {
         name: string;
         slug: Slug;
+        _id: string;
       }[];
     };
   };

--- a/web/pages/[[...slug]].tsx
+++ b/web/pages/[[...slug]].tsx
@@ -6,6 +6,8 @@ import TextBlock from '../components/TextBlock';
 import GridWrapper from '../components/GridWrapper';
 import ConferenceHeader from '../components/ConferenceHeader';
 import NavBlock from '../components/NavBlock';
+import Footer from "../components/Footer";
+import { Slug } from "../types/Slug";
 
 const QUERY = groq`
   {
@@ -50,7 +52,13 @@ const QUERY = groq`
       startDate,
       endDate,
       description,
-    }
+    },
+    "footer": *[_id == "secondary-nav"][0] {
+      "links": tree[].value.reference-> {
+        "name": seo.title,
+        slug,
+      }
+    },
   }`;
 
 interface RouteProps {
@@ -67,6 +75,12 @@ interface RouteProps {
       endDate: string;
       description: string;
     };
+    footer: {
+      links: {
+        name: string;
+        slug: Slug;
+      }[];
+    };
   };
   slug: string;
 }
@@ -77,10 +91,12 @@ const Route = ({
       page: { name, sections },
     },
     home: { name: homeName, startDate, endDate, description },
+    footer,
   },
   slug,
 }: RouteProps) => (
   <>
+    <main>
     {slug === '/' ? (
       <GridWrapper>
         <ConferenceHeader
@@ -95,6 +111,8 @@ const Route = ({
       <Hero heading={name} />
     )}
     <TextBlock value={sections} />
+    </main>
+    <Footer links={footer.links} />
   </>
 );
 

--- a/web/pages/_app.tsx
+++ b/web/pages/_app.tsx
@@ -3,7 +3,6 @@ import { getCookieConsentValue } from 'react-cookie-consent';
 import TagManager from 'react-gtm-module';
 import clsx from 'clsx';
 import CookieConsent from '../components/CookieConsent';
-import Footer from '../components/Footer';
 import Nav from '../components/Nav';
 import '../styles/globals.css';
 import styles from './app.module.css';
@@ -52,10 +51,7 @@ function MyApp({ Component, pageProps, router }) {
       <header className={headerClasses}>
         <Nav onFrontPage={isFrontPage} />
       </header>
-      <main>
-        <Component {...pageProps} />
-      </main>
-      <Footer />
+      <Component {...pageProps} />
       <div className={styles.cookieConsent}>
         <CookieConsent />
       </div>


### PR DESCRIPTION
# Footer links from sanity

## Intent

A small, neat PR, for once! :stuck_out_tongue: 

- Moves `<main>` and `<Footer>` to _[[...slug]].tsx_. (See 921dac8e1be492f76cc47db4d3b07efa8b5a11a1)
- Fetches `secondary-nav` data from Sanity and passes it down to Footer


## Testing this PR

Verify that the Footer of the [Preview Deploy](https://structured-content-2022-web-74tkegg06.sanity.build/) renders the same links as those listed in the [Secondary Navigation](https://structured-content-2022-studio-im9uwvsd9.sanity.build/desk/navigation;secondary-nav) group in Sanity.