### PR TITLE
/registration-info tweaks

### DIFF
--- a/web/components/TextBlock/QuestionAndAnswerCollection/QuestionAndAnswerCollection.module.css
+++ b/web/components/TextBlock/QuestionAndAnswerCollection/QuestionAndAnswerCollection.module.css
@@ -1,3 +1,10 @@
+.question {
+  margin: 4px 80px;
+  background: var(--color-brand-yellow-light);
+  padding: 80px 20px;
+  border-radius: 12px;
+}
+
 .question:not(:last-child) {
-  padding-bottom: 1rem;
+  padding-bottom: var(--spacing-small);
 }

--- a/web/components/TextBlock/QuestionAndAnswerCollection/QuestionAndAnswerCollection.tsx
+++ b/web/components/TextBlock/QuestionAndAnswerCollection/QuestionAndAnswerCollection.tsx
@@ -1,13 +1,12 @@
 import Heading from '../../Heading';
 import Block from '../Block';
-import SectionBlock from '../../SectionBlock';
+import GridWrapper from "../../GridWrapper";
 import styles from './QuestionAndAnswerCollection.module.css';
 
 export const QuestionAndAnswerCollection = ({
-  value: { questions, title },
+  value: { questions },
 }) => (
-  <SectionBlock>
-    <Heading type="h2">{title}</Heading>
+  <GridWrapper>
     {questions.map(({ _key, question, answer }) => (
       <div key={_key} className={styles.question}>
         <Heading type="h3">{question}</Heading>
@@ -16,5 +15,5 @@ export const QuestionAndAnswerCollection = ({
         ))}
       </div>
     ))}
-  </SectionBlock>
+  </GridWrapper>
 );

--- a/web/components/TextBlock/TextBlock/TextBlock.tsx
+++ b/web/components/TextBlock/TextBlock/TextBlock.tsx
@@ -20,7 +20,7 @@ const components: Partial<PortableTextComponents> = {
     richText: RichText,
     person: Person,
     venue: Venue,
-    questionAndAnswerCollection: QuestionAndAnswerCollection,
+    questionAndAnswerCollectionSection: QuestionAndAnswerCollection,
     block: Block,
     textAndImageSection: TextAndImage,
     sharedSections: SharedSections,

--- a/web/pages/[[...slug]].tsx
+++ b/web/pages/[[...slug]].tsx
@@ -24,6 +24,10 @@ const QUERY = groq`
                   sponsorship->,
                 },
               },
+              _type == "simpleCallToAction" => {
+                ...,
+                reference->,
+              },
               _type == "venuesSection" => {
                 ...,
                 "venues": *[_type == "venue"]


### PR DESCRIPTION
# /registration-info tweaks

## Intent

- Map `QuestionAndAnswerCollection` component to `questionAndAnswerCollection**Section**` type, this component had stopped rendering because the section name had changed
- Make `QuestionAndAnswerCollection` (as seen e.g. on [/registration-info](https://structured-content-2022-web-ai10g6e8k.sanity.build/registration-info)) render a tad bit more like the Figma sketches 
  - (I'm going to need your magic touch to finalize this @oyvind-stenhaug)
- Make `simpleCallToAction` buttons render once again
- Performed small tweaks in the Studio content for the [Registration Info](https://structured-content-2022-studio-njnao6tge.sanity.build/desk/page;8e0a4c73-2b2a-43c9-84a4-7a00c286aa86) Landing Page, adding a "mailchimp" `sharedSection` and other small changes to make the content mimic Figma sketches more


## Testing this PR

Verify that the elements mentioned above make the /registration-info page resemble the Figma sketches more closely.