### PR TITLE
Fix VenuesSection layout

### DIFF
--- a/web/components/TextBlock/VenuesSection/VenuesSection.tsx
+++ b/web/components/TextBlock/VenuesSection/VenuesSection.tsx
@@ -1,3 +1,4 @@
+import GridWrapper from '../../GridWrapper';
 import VenueNames from '../../VenueNames';
 
 export const VenuesSection = ({ value: { type, venues } }) => {
@@ -6,5 +7,9 @@ export const VenuesSection = ({ value: { type, venues } }) => {
     return null;
   }
 
-  return <VenueNames venues={venues} />;
+  return (
+    <GridWrapper>
+      <VenueNames venues={venues} />
+    </GridWrapper>
+  );
 };


### PR DESCRIPTION
# Fix VenuesSection layout

## Intent

Fix venues section being too wide

## Description

I overlooked this in https://github.com/sanity-io/structured-content-2022/pull/47, it's sort of a regression. On the old /home page, Venues was wrapped in a GridWrapper, but this is missing in the new TextBlock-based regime.

I originally wrote it so that the Venues component itself doesn't have a wrapper, because the Figma sketches looked like the same component might be used in a different context/layout. Perhaps this is not relevant anymore, but in any case the VenuesSection seems like a sensible place to have the wrapper.

## Testing this PR

1. Open the [front page](https://structured-content-2022-web-git-fix-venue-names-section-layout.sanity.build/)
2. Make sure the window is really wide
2. Scroll down and verify that the venue names list ("Oslo HQ • New York […]") isn't wider than the "nav block" of yellow boxes above (the exact way this text renders depends somewhat on the default sans-serif font on your system, so inspecting the `ul` element in the browser's dev tools might also be useful)