### PR TITLE
Q&A frontend adjustments

### DIFF
--- a/web/components/Heading/Heading.module.css
+++ b/web/components/Heading/Heading.module.css
@@ -19,4 +19,8 @@
     font: var(--font-display-base);
     margin-bottom: 30px;
   }
+
+  .h3 {
+    font: var(--font-display-sm);
+  }
 }

--- a/web/components/TextBlock/QuestionAndAnswerCollection/QuestionAndAnswerCollection.module.css
+++ b/web/components/TextBlock/QuestionAndAnswerCollection/QuestionAndAnswerCollection.module.css
@@ -1,10 +1,45 @@
-.question {
-  margin: 4px 80px;
+.container {
+  margin: 80px 0;
+}
+
+.section {
+  margin: 8px 0;
   background: var(--color-brand-yellow-light);
-  padding: 80px 20px;
+  padding: 48px 32px;
   border-radius: 12px;
 }
 
-.question:not(:last-child) {
-  padding-bottom: var(--spacing-small);
+.answer {
+  margin-top: 22px;
+}
+
+@media (--medium-up) {
+  .container {
+    margin: 96px 0;
+    display: grid;
+    grid-template-columns: repeat(8, minmax(0, 1fr));
+    column-gap: var(--grid-medium-gutter);
+  }
+
+  .section {
+    padding: 64px 52px;
+    grid-column: 2 / span 6;
+    margin-left: -52px;
+    margin-right: -52px;
+  }
+}
+
+@media (--large-up) {
+  .container {
+    margin: 128px 0;
+    grid-template-columns: repeat(12, minmax(0, 1fr));
+    column-gap: var(--grid-gutter);
+  }
+
+  .section {
+    padding: 64px;
+    grid-column: 4 / span 6;
+    margin-left: -64px;
+    margin-right: -64px;
+  }
 }

--- a/web/components/TextBlock/QuestionAndAnswerCollection/QuestionAndAnswerCollection.module.css
+++ b/web/components/TextBlock/QuestionAndAnswerCollection/QuestionAndAnswerCollection.module.css
@@ -16,16 +16,14 @@
 @media (--medium-up) {
   .container {
     margin: 96px 0;
-    display: grid;
-    grid-template-columns: repeat(8, minmax(0, 1fr));
-    column-gap: var(--grid-medium-gutter);
   }
 
   .section {
     padding: 64px 52px;
-    grid-column: 2 / span 6;
-    margin-left: -52px;
-    margin-right: -52px;
+    box-sizing: content-box;
+    max-width: 37.5rem;
+    margin-left: auto;
+    margin-right: auto;
   }
 }
 
@@ -38,8 +36,5 @@
 
   .section {
     padding: 64px;
-    grid-column: 4 / span 6;
-    margin-left: -64px;
-    margin-right: -64px;
   }
 }

--- a/web/components/TextBlock/QuestionAndAnswerCollection/QuestionAndAnswerCollection.module.css
+++ b/web/components/TextBlock/QuestionAndAnswerCollection/QuestionAndAnswerCollection.module.css
@@ -21,7 +21,7 @@
   .section {
     padding: 64px 52px;
     box-sizing: content-box;
-    max-width: 37.5rem;
+    max-width: var(--max-body-text-width);
     margin-left: auto;
     margin-right: auto;
   }

--- a/web/components/TextBlock/QuestionAndAnswerCollection/QuestionAndAnswerCollection.tsx
+++ b/web/components/TextBlock/QuestionAndAnswerCollection/QuestionAndAnswerCollection.tsx
@@ -1,19 +1,21 @@
 import Heading from '../../Heading';
 import Block from '../Block';
-import GridWrapper from "../../GridWrapper";
+import GridWrapper from '../../GridWrapper';
 import styles from './QuestionAndAnswerCollection.module.css';
 
-export const QuestionAndAnswerCollection = ({
-  value: { questions },
-}) => (
+export const QuestionAndAnswerCollection = ({ value: { questions } }) => (
   <GridWrapper>
-    {questions.map(({ _key, question, answer }) => (
-      <div key={_key} className={styles.question}>
-        <Heading type="h3">{question}</Heading>
-        {answer.map((value) => (
-          <Block key={value._key} value={value} />
-        ))}
-      </div>
-    ))}
+    <div className={styles.container}>
+      {questions.map(({ _key, question, answer }) => (
+        <section key={_key} className={styles.section}>
+          <Heading type="h3">{question}</Heading>
+          <div className={styles.answer}>
+            {answer.map((value) => (
+              <Block key={value._key} value={value} />
+            ))}
+          </div>
+        </section>
+      ))}
+    </div>
   </GridWrapper>
 );

--- a/web/components/TextBlock/RichText/RichText.module.css
+++ b/web/components/TextBlock/RichText/RichText.module.css
@@ -22,7 +22,7 @@
   }
 
   .content {
-    max-width: 37.5rem;
+    max-width: var(--max-body-text-width);
     margin: 0 auto;
   }
 }

--- a/web/components/TextBlock/RichText/RichText.module.css
+++ b/web/components/TextBlock/RichText/RichText.module.css
@@ -15,9 +15,6 @@
 @media (--medium-up) {
   .container {
     margin: 96px 0;
-    display: grid;
-    grid-template-columns: repeat(8, minmax(0, 1fr));
-    column-gap: var(--grid-medium-gutter);
   }
 
   .container.background {
@@ -25,22 +22,17 @@
   }
 
   .content {
-    grid-column: 2 / span 6;
+    max-width: 37.5rem;
+    margin: 0 auto;
   }
 }
 
 @media (--large-up) {
   .container {
     margin: 128px 0;
-    grid-template-columns: repeat(12, minmax(0, 1fr));
-    column-gap: var(--grid-gutter);
   }
 
   .container.background {
     padding: 128px 0;
-  }
-
-  .content {
-    grid-column: 4 / span 6;
   }
 }

--- a/web/styles/variables.css
+++ b/web/styles/variables.css
@@ -31,6 +31,7 @@
   --letter-spacing-body-xl: -0.019em;
   --letter-spacing-ui-sm: -0.011em;
   --letter-spacing-ui-xxl: -0.022em;
+  --max-body-text-width: 37.5rem;
   --spacing-small: 40px;
   --spacing-medium: 64px;
   --spacing-large: 128px;


### PR DESCRIPTION
# Q&A frontend adjustments

## Intent

Adjust the styling for the `QuestionAndAnswerCollection` component, so that it's more in line with the Figma sketches and e.g. so the boxes aren't extremely narrow on small (mobile-ish) viewports

## Description

Mostly CSS changes specific to the component. The heading font change for `--medium-up` also affects Sponsors, which is intentional. (Must have accidentally left out that part.)

Also adjusts the RichText layout, since—as clarified with the designer—we won't use the standard 8-/12-column layout grids for this "body text" type of content. Instead the idea is to have a fixed max-width, for readability purposes. (600px, though I've chosen to convert it to `rem` here so that it'll behave a little better if there is text-only zoom in effect).

Adjusting both these components in tandem ensures their text contents are aligned horizontally (except the smallest breakpoint).

## Testing this PR
1. Open the [/registration-info](https://structured-content-2022-web-git-qna-frontend-adjustments.sanity.build/registration-info) page
2. Verify that the Q&A sections ("What does a “hybrid event” mean?" etc) look OK