### PR TITLE
Tickets.tsx: Support `ticketsSection` type section in [[...slug]].tsx

### DIFF
--- a/web/components/TextBlock/QuestionAndAnswerCollection/QuestionAndAnswerCollection.tsx
+++ b/web/components/TextBlock/QuestionAndAnswerCollection/QuestionAndAnswerCollection.tsx
@@ -1,11 +1,9 @@
 import Heading from '../../Heading';
 import Block from '../Block';
-import GridWrapper from "../../GridWrapper";
+import GridWrapper from '../../GridWrapper';
 import styles from './QuestionAndAnswerCollection.module.css';
 
-export const QuestionAndAnswerCollection = ({
-  value: { questions },
-}) => (
+export const QuestionAndAnswerCollection = ({ value: { questions } }) => (
   <GridWrapper>
     {questions.map(({ _key, question, answer }) => (
       <div key={_key} className={styles.question}>

--- a/web/components/TextBlock/TextBlock/TextBlock.tsx
+++ b/web/components/TextBlock/TextBlock/TextBlock.tsx
@@ -14,6 +14,7 @@ import SimpleCallToAction from '../SimpleCallToAction';
 import ConferenceUpdatesForm from '../../ConferenceUpdatesForm';
 import VenuesSection from '../VenuesSection';
 import SponsorsSection from '../SponsorsSection';
+import Tickets from '../Tickets';
 
 const components: Partial<PortableTextComponents> = {
   types: {
@@ -29,6 +30,7 @@ const components: Partial<PortableTextComponents> = {
     articleSection: RichText,
     venuesSection: VenuesSection,
     sponsorsSection: SponsorsSection,
+    ticketsSection: Tickets,
   },
   marks: {
     bold: ({ children }) => <strong>{children}</strong>,

--- a/web/components/TextBlock/Tickets/Tickets.module.css
+++ b/web/components/TextBlock/Tickets/Tickets.module.css
@@ -1,3 +1,13 @@
+.table {
+  display: none;
+}
+
+.sections {
+  font: var(--font-body-small-medium);
+  letter-spacing: var(--letter-spacing-body-small);
+  margin: 48px 0;
+}
+
 .ticketInfo {
   background-color: var(--color-brand-yellow);
   padding: 24px;
@@ -14,31 +24,45 @@
   border-bottom-right-radius: 0;
 }
 
-.ticketFeaturesListItem {
+.name {
+  margin: 0 0 24px;
+  font: var(--font-body-large-bold);
+  letter-spacing: var(--font-body-large);
+}
+
+.priceList {
+  margin: 0;
+}
+
+.priceLabel {
+  color: var(--color-material-gray-600);
+}
+
+.price {
+  margin: 0;
+  font: var(--font-body-small-bold);
+}
+
+.ticketFeatures {
   list-style-type: none;
   padding: 24px;
-  vertical-align: center;
   border: 1px solid var(--color-brand-yellow);
   border-bottom-left-radius: 8px;
   border-bottom-right-radius: 8px;
+  margin-bottom: 8px;
 }
 
 .includedFeature:not(:last-child) {
-  padding-bottom: 12px;
+  padding-bottom: 16px;
+}
+
+.icon {
+  vertical-align: top;
 }
 
 .includedFeatureDescription {
   padding-left: 12px;
   text-transform: capitalize;
-}
-
-.name {
-  margin-bottom: 24px;
-}
-
-.name,
-.price {
-  font-weight: bold;
 }
 
 .feature {
@@ -58,20 +82,12 @@
   background-color: var(--color-brand-yellow-light);
 }
 
-.icon {
-  vertical-align: top;
-}
-
-.list {
-  display: none;
-}
-
-@media not all and (--medium-up) {
+@media (--medium-up) {
   .table {
-    display: none;
+    display: table;
   }
 
-  .list {
-    display: block;
+  .sections {
+    display: none;
   }
 }

--- a/web/components/TextBlock/Tickets/Tickets.module.css
+++ b/web/components/TextBlock/Tickets/Tickets.module.css
@@ -1,9 +1,36 @@
-.ticketType {
+.ticketInfo {
   background-color: var(--color-brand-yellow);
-  margin: 4px;
   padding: 24px;
   border-radius: 8px;
+}
+
+.ticketInfoColumn {
   width: 265px;
+  margin: 4px;
+}
+
+.ticketInfoListItem {
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.ticketFeaturesListItem {
+  list-style-type: none;
+  padding: 24px;
+  vertical-align: center;
+  border: 1px solid var(--color-brand-yellow);
+  border-bottom-left-radius: 8px;
+  border-bottom-right-radius: 8px;
+}
+
+
+.includedFeature:not(:last-child) {
+  padding-bottom: 12px;
+}
+
+.includedFeatureDescription {
+  padding-left: 12px;
+  text-transform: capitalize;
 }
 
 .name {
@@ -35,6 +62,7 @@
 .checkmark {
   border-radius: 4px;
   background-color: var(--color-brand-orange);
+  text-align: center;
 }
 
 .cross {
@@ -47,4 +75,19 @@
   width: 24px;
   height: 24px;
   margin: 0 auto;
+  display: inline-block;
+}
+
+.list {
+  display: none;
+}
+
+@media not all and (--medium-up) {
+  .table {
+    display: none;
+  }
+
+  .list {
+    display: block;
+  }
 }

--- a/web/components/TextBlock/Tickets/Tickets.module.css
+++ b/web/components/TextBlock/Tickets/Tickets.module.css
@@ -82,7 +82,13 @@
   background-color: var(--color-brand-yellow-light);
 }
 
-@media (--medium-up) {
+@media (-medium-up) {
+  .sections {
+    margin: 64px 0;
+  }
+}
+
+@media (--large-up) {
   .table {
     display: table;
   }

--- a/web/components/TextBlock/Tickets/Tickets.module.css
+++ b/web/components/TextBlock/Tickets/Tickets.module.css
@@ -23,7 +23,6 @@
   border-bottom-right-radius: 8px;
 }
 
-
 .includedFeature:not(:last-child) {
   padding-bottom: 12px;
 }

--- a/web/components/TextBlock/Tickets/Tickets.module.css
+++ b/web/components/TextBlock/Tickets/Tickets.module.css
@@ -58,23 +58,8 @@
   background-color: var(--color-brand-yellow-light);
 }
 
-.checkmark {
-  border-radius: 4px;
-  background-color: var(--color-brand-orange);
-  text-align: center;
-}
-
-.cross {
-  border-radius: 16px;
-  background-color: var(--color-ui-gray-300);
-}
-
-.checkmark,
-.cross {
-  width: 24px;
-  height: 24px;
-  margin: 0 auto;
-  display: inline-block;
+.icon {
+  vertical-align: top;
 }
 
 .list {

--- a/web/components/TextBlock/Tickets/Tickets.module.css
+++ b/web/components/TextBlock/Tickets/Tickets.module.css
@@ -1,0 +1,50 @@
+.ticketType {
+  background-color: var(--color-brand-yellow);
+  margin: 4px;
+  padding: 24px;
+  border-radius: 8px;
+  width: 265px;
+}
+
+.name {
+  margin-bottom: 24px;
+}
+
+.name,
+.price {
+  font-weight: bold;
+}
+
+.feature {
+  border: 1px solid #f4f3ef;
+  width: 265px;
+  height: 114px;
+  text-align: center;
+  padding: 24px;
+  text-transform: capitalize;
+}
+
+.feature:first-of-type {
+  text-align: left;
+}
+
+.featureIncluded {
+  background-color: var(--color-brand-yellow-light);
+}
+
+.checkmark {
+  border-radius: 4px;
+  background-color: var(--color-brand-orange);
+}
+
+.cross {
+  border-radius: 16px;
+  background-color: var(--color-ui-gray-300);
+}
+
+.checkmark,
+.cross {
+  width: 24px;
+  height: 24px;
+  margin: 0 auto;
+}

--- a/web/components/TextBlock/Tickets/Tickets.module.css
+++ b/web/components/TextBlock/Tickets/Tickets.module.css
@@ -1,5 +1,8 @@
 .table {
   display: none;
+  width: 100%;
+  border-spacing: 8px;
+  margin: 96px 0;
 }
 
 .sections {
@@ -12,14 +15,11 @@
   background-color: var(--color-brand-yellow);
   padding: 24px;
   border-radius: 8px;
+  font: inherit;
+  text-align: left;
 }
 
-.ticketInfoColumn {
-  width: 265px;
-  margin: 4px;
-}
-
-.ticketInfoListItem {
+.ticketInfo.inSections {
   border-bottom-left-radius: 0;
   border-bottom-right-radius: 0;
 }
@@ -65,17 +65,23 @@
   text-transform: capitalize;
 }
 
-.feature {
-  border: 1px solid #f4f3ef;
+.feature,
+.featurePresence {
+  border: 1px solid var(--color-ui-gray-100);
   width: 265px;
   height: 114px;
-  text-align: center;
   padding: 24px;
+  border-radius: 8px;
+}
+
+.feature {
+  font: inherit;
+  text-align: left;
   text-transform: capitalize;
 }
 
-.feature:first-of-type {
-  text-align: left;
+.featurePresence {
+  text-align: center;
 }
 
 .featureIncluded {

--- a/web/components/TextBlock/Tickets/Tickets.tsx
+++ b/web/components/TextBlock/Tickets/Tickets.tsx
@@ -1,0 +1,72 @@
+import { Ticket } from '../../../types/Ticket';
+import styles from './Tickets.module.css';
+import clsx from 'clsx';
+
+interface TicketsProps {
+  value: {
+    type: 'all';
+    tickets: Ticket[];
+  };
+}
+
+export const Tickets = ({ value: { type, tickets } }: TicketsProps) => {
+  if (type !== 'all') {
+    console.error(`Unrecognized SponsorsSection type: '${type}'`);
+    return null;
+  }
+
+  if (!Array.isArray(tickets) || tickets.length === 0) {
+    console.error(`Tickets missing or invalid tickets array: '${tickets}'`);
+    return null;
+  }
+
+  // GROQ has no "distinct"/"set" function
+  const includedTypes = Array.from(
+    new Set(tickets.map((ticket) => ticket.included).flat())
+  );
+  return (
+    <table>
+      <thead>
+        <tr>
+          <td />
+          {tickets.map((ticket) => (
+            <td key={ticket._id} className={styles.ticketType}>
+              <div className={styles.name}>{ticket.type}</div>
+              <div>
+                <div>Price</div>
+                <div className={styles.price}>
+                  {ticket.price ? `$${ticket.price}` : 'Free'}
+                </div>
+              </div>
+            </td>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {includedTypes.map((includedType) => (
+          <tr key={includedType}>
+            <td className={styles.feature}>{includedType}</td>
+            {tickets.map((ticket) => {
+              const featureIncluded = ticket.included.includes(includedType);
+              return (
+                <td
+                  key={ticket._id}
+                  className={clsx(
+                    styles.feature,
+                    featureIncluded && styles.featureIncluded
+                  )}
+                >
+                  {featureIncluded ? (
+                    <div className={styles.checkmark}>&#10004;</div>
+                  ) : (
+                    <div className={styles.cross}>&#10008;</div>
+                  )}
+                </td>
+              );
+            })}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+};

--- a/web/components/TextBlock/Tickets/Tickets.tsx
+++ b/web/components/TextBlock/Tickets/Tickets.tsx
@@ -1,4 +1,5 @@
 import { Ticket } from '../../../types/Ticket';
+import GridWrapper from '../../GridWrapper';
 import styles from './Tickets.module.css';
 import clsx from 'clsx';
 
@@ -25,7 +26,7 @@ export const Tickets = ({ value: { type, tickets } }: TicketsProps) => {
     new Set(tickets.map((ticket) => ticket.included).flat())
   );
   return (
-    <>
+    <GridWrapper>
       <table className={styles.table}>
         <thead>
           <tr>
@@ -101,6 +102,6 @@ export const Tickets = ({ value: { type, tickets } }: TicketsProps) => {
           </>
         ))}
       </div>
-    </>
+    </GridWrapper>
   );
 };

--- a/web/components/TextBlock/Tickets/Tickets.tsx
+++ b/web/components/TextBlock/Tickets/Tickets.tsx
@@ -90,19 +90,19 @@ export const Tickets = ({ value: { type, tickets } }: TicketsProps) => {
         </tbody>
       </table>
 
-      <div className={styles.list}>
+      <div className={styles.sections}>
         {tickets.map((ticket) => (
           <section key={ticket._id}>
             <div className={clsx(styles.ticketInfo, styles.ticketInfoListItem)}>
-              <div className={styles.name}>{ticket.type}</div>
-              <div>
-                <div>Price</div>
-                <div className={styles.price}>
+              <h3 className={styles.name}>{ticket.type}</h3>
+              <dl className={styles.priceList}>
+                <dt className={styles.priceLabel}>Price</dt>
+                <dd className={styles.price}>
                   {ticket.price ? `$${ticket.price}` : 'Free'}
-                </div>
-              </div>
+                </dd>
+              </dl>
             </div>
-            <ul className={styles.ticketFeaturesListItem}>
+            <ul className={styles.ticketFeatures}>
               {ticket.included.map((included) => (
                 <li key={included} className={styles.includedFeature}>
                   {/* eslint-disable-next-line @next/next/no-img-element */}

--- a/web/components/TextBlock/Tickets/Tickets.tsx
+++ b/web/components/TextBlock/Tickets/Tickets.tsx
@@ -25,12 +25,13 @@ export const Tickets = ({ value: { type, tickets } }: TicketsProps) => {
     new Set(tickets.map((ticket) => ticket.included).flat())
   );
   return (
-    <table>
+    <>
+    <table className={styles.table}>
       <thead>
         <tr>
           <td />
           {tickets.map((ticket) => (
-            <td key={ticket._id} className={styles.ticketType}>
+            <td key={ticket._id} className={clsx(styles.ticketInfo, styles.ticketInfoColumn)}>
               <div className={styles.name}>{ticket.type}</div>
               <div>
                 <div>Price</div>
@@ -68,5 +69,28 @@ export const Tickets = ({ value: { type, tickets } }: TicketsProps) => {
         ))}
       </tbody>
     </table>
+
+    <div className={styles.list}>
+      {tickets.map((ticket) => (
+        <>
+        <div key={ticket._id} className={clsx(styles.ticketInfo, styles.ticketInfoListItem)}>
+          <div className={styles.name}>{ticket.type}</div>
+          <div>
+            <div>Price</div>
+            <div className={styles.price}>{ticket.price ? `$${ticket.price}` : 'Free'}</div>
+          </div>
+        </div>
+          <ul className={styles.ticketFeaturesListItem}>
+            {ticket.included.map((included) => (
+              <li key={included} className={styles.includedFeature}>
+                <span className={styles.checkmark}>&#10004;</span>
+                <span className={styles.includedFeatureDescription}>{included}</span>
+              </li>
+            ))}
+          </ul>
+        </>
+      ))}
+    </div>
+  </>
   );
 };

--- a/web/components/TextBlock/Tickets/Tickets.tsx
+++ b/web/components/TextBlock/Tickets/Tickets.tsx
@@ -76,11 +76,8 @@ export const Tickets = ({ value: { type, tickets } }: TicketsProps) => {
 
       <div className={styles.list}>
         {tickets.map((ticket) => (
-          <>
-            <div
-              key={ticket._id}
-              className={clsx(styles.ticketInfo, styles.ticketInfoListItem)}
-            >
+          <section key={ticket._id}>
+            <div className={clsx(styles.ticketInfo, styles.ticketInfoListItem)}>
               <div className={styles.name}>{ticket.type}</div>
               <div>
                 <div>Price</div>
@@ -99,7 +96,7 @@ export const Tickets = ({ value: { type, tickets } }: TicketsProps) => {
                 </li>
               ))}
             </ul>
-          </>
+          </section>
         ))}
       </div>
     </GridWrapper>

--- a/web/components/TextBlock/Tickets/Tickets.tsx
+++ b/web/components/TextBlock/Tickets/Tickets.tsx
@@ -26,12 +26,60 @@ export const Tickets = ({ value: { type, tickets } }: TicketsProps) => {
   );
   return (
     <>
-    <table className={styles.table}>
-      <thead>
-        <tr>
-          <td />
-          {tickets.map((ticket) => (
-            <td key={ticket._id} className={clsx(styles.ticketInfo, styles.ticketInfoColumn)}>
+      <table className={styles.table}>
+        <thead>
+          <tr>
+            <td />
+            {tickets.map((ticket) => (
+              <td
+                key={ticket._id}
+                className={clsx(styles.ticketInfo, styles.ticketInfoColumn)}
+              >
+                <div className={styles.name}>{ticket.type}</div>
+                <div>
+                  <div>Price</div>
+                  <div className={styles.price}>
+                    {ticket.price ? `$${ticket.price}` : 'Free'}
+                  </div>
+                </div>
+              </td>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {includedTypes.map((includedType) => (
+            <tr key={includedType}>
+              <td className={styles.feature}>{includedType}</td>
+              {tickets.map((ticket) => {
+                const featureIncluded = ticket.included.includes(includedType);
+                return (
+                  <td
+                    key={ticket._id}
+                    className={clsx(
+                      styles.feature,
+                      featureIncluded && styles.featureIncluded
+                    )}
+                  >
+                    {featureIncluded ? (
+                      <div className={styles.checkmark}>&#10004;</div>
+                    ) : (
+                      <div className={styles.cross}>&#10008;</div>
+                    )}
+                  </td>
+                );
+              })}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <div className={styles.list}>
+        {tickets.map((ticket) => (
+          <>
+            <div
+              key={ticket._id}
+              className={clsx(styles.ticketInfo, styles.ticketInfoListItem)}
+            >
               <div className={styles.name}>{ticket.type}</div>
               <div>
                 <div>Price</div>
@@ -39,58 +87,20 @@ export const Tickets = ({ value: { type, tickets } }: TicketsProps) => {
                   {ticket.price ? `$${ticket.price}` : 'Free'}
                 </div>
               </div>
-            </td>
-          ))}
-        </tr>
-      </thead>
-      <tbody>
-        {includedTypes.map((includedType) => (
-          <tr key={includedType}>
-            <td className={styles.feature}>{includedType}</td>
-            {tickets.map((ticket) => {
-              const featureIncluded = ticket.included.includes(includedType);
-              return (
-                <td
-                  key={ticket._id}
-                  className={clsx(
-                    styles.feature,
-                    featureIncluded && styles.featureIncluded
-                  )}
-                >
-                  {featureIncluded ? (
-                    <div className={styles.checkmark}>&#10004;</div>
-                  ) : (
-                    <div className={styles.cross}>&#10008;</div>
-                  )}
-                </td>
-              );
-            })}
-          </tr>
+            </div>
+            <ul className={styles.ticketFeaturesListItem}>
+              {ticket.included.map((included) => (
+                <li key={included} className={styles.includedFeature}>
+                  <span className={styles.checkmark}>&#10004;</span>
+                  <span className={styles.includedFeatureDescription}>
+                    {included}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </>
         ))}
-      </tbody>
-    </table>
-
-    <div className={styles.list}>
-      {tickets.map((ticket) => (
-        <>
-        <div key={ticket._id} className={clsx(styles.ticketInfo, styles.ticketInfoListItem)}>
-          <div className={styles.name}>{ticket.type}</div>
-          <div>
-            <div>Price</div>
-            <div className={styles.price}>{ticket.price ? `$${ticket.price}` : 'Free'}</div>
-          </div>
-        </div>
-          <ul className={styles.ticketFeaturesListItem}>
-            {ticket.included.map((included) => (
-              <li key={included} className={styles.includedFeature}>
-                <span className={styles.checkmark}>&#10004;</span>
-                <span className={styles.includedFeatureDescription}>{included}</span>
-              </li>
-            ))}
-          </ul>
-        </>
-      ))}
-    </div>
-  </>
+      </div>
+    </>
   );
 };

--- a/web/components/TextBlock/Tickets/Tickets.tsx
+++ b/web/components/TextBlock/Tickets/Tickets.tsx
@@ -1,5 +1,7 @@
 import { Ticket } from '../../../types/Ticket';
 import GridWrapper from '../../GridWrapper';
+import checkmarkIcon from '../../../images/checkmark.svg';
+import crossIcon from '../../../images/cross.svg';
 import styles from './Tickets.module.css';
 import clsx from 'clsx';
 
@@ -61,11 +63,25 @@ export const Tickets = ({ value: { type, tickets } }: TicketsProps) => {
                       featureIncluded && styles.featureIncluded
                     )}
                   >
+                    {/* eslint-disable @next/next/no-img-element */}
                     {featureIncluded ? (
-                      <div className={styles.checkmark}>&#10004;</div>
+                      <img
+                        src={checkmarkIcon.src}
+                        className={styles.icon}
+                        width={checkmarkIcon.width}
+                        height={checkmarkIcon.height}
+                        alt="Included"
+                      />
                     ) : (
-                      <div className={styles.cross}>&#10008;</div>
+                      <img
+                        src={crossIcon.src}
+                        className={styles.icon}
+                        width={crossIcon.width}
+                        height={crossIcon.height}
+                        alt="Not included"
+                      />
                     )}
+                    {/* eslint-enable @next/next/no-img-element */}
                   </td>
                 );
               })}
@@ -89,7 +105,14 @@ export const Tickets = ({ value: { type, tickets } }: TicketsProps) => {
             <ul className={styles.ticketFeaturesListItem}>
               {ticket.included.map((included) => (
                 <li key={included} className={styles.includedFeature}>
-                  <span className={styles.checkmark}>&#10004;</span>
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  <img
+                    src={checkmarkIcon.src}
+                    className={styles.icon}
+                    width={checkmarkIcon.width}
+                    height={checkmarkIcon.height}
+                    alt=""
+                  />
                   <span className={styles.includedFeatureDescription}>
                     {included}
                   </span>

--- a/web/components/TextBlock/Tickets/Tickets.tsx
+++ b/web/components/TextBlock/Tickets/Tickets.tsx
@@ -32,34 +32,33 @@ export const Tickets = ({ value: { type, tickets } }: TicketsProps) => {
       <table className={styles.table}>
         <thead>
           <tr>
-            <td />
+            <th />
             {tickets.map((ticket) => (
-              <td
-                key={ticket._id}
-                className={clsx(styles.ticketInfo, styles.ticketInfoColumn)}
-              >
+              <th key={ticket._id} scope="col" className={styles.ticketInfo}>
                 <div className={styles.name}>{ticket.type}</div>
-                <div>
-                  <div>Price</div>
-                  <div className={styles.price}>
+                <dl className={styles.priceList}>
+                  <dt className={styles.priceLabel}>Price</dt>
+                  <dd className={styles.price}>
                     {ticket.price ? `$${ticket.price}` : 'Free'}
-                  </div>
-                </div>
-              </td>
+                  </dd>
+                </dl>
+              </th>
             ))}
           </tr>
         </thead>
         <tbody>
           {includedTypes.map((includedType) => (
             <tr key={includedType}>
-              <td className={styles.feature}>{includedType}</td>
+              <th className={styles.feature} scope="row">
+                {includedType}
+              </th>
               {tickets.map((ticket) => {
                 const featureIncluded = ticket.included.includes(includedType);
                 return (
                   <td
                     key={ticket._id}
                     className={clsx(
-                      styles.feature,
+                      styles.featurePresence,
                       featureIncluded && styles.featureIncluded
                     )}
                   >
@@ -93,7 +92,7 @@ export const Tickets = ({ value: { type, tickets } }: TicketsProps) => {
       <div className={styles.sections}>
         {tickets.map((ticket) => (
           <section key={ticket._id}>
-            <div className={clsx(styles.ticketInfo, styles.ticketInfoListItem)}>
+            <div className={clsx(styles.ticketInfo, styles.inSections)}>
               <h3 className={styles.name}>{ticket.type}</h3>
               <dl className={styles.priceList}>
                 <dt className={styles.priceLabel}>Price</dt>

--- a/web/components/TextBlock/Tickets/index.ts
+++ b/web/components/TextBlock/Tickets/index.ts
@@ -1,0 +1,1 @@
+export { Tickets as default } from './Tickets';

--- a/web/images/checkmark.svg
+++ b/web/images/checkmark.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="24" height="24" rx="4" fill="#FFBA00"/>
+<path d="M8 12L11 15L17 9" stroke="black" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/web/images/cross.svg
+++ b/web/images/cross.svg
@@ -1,0 +1,5 @@
+<svg width="25" height="24" viewBox="0 0 25 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="0.201172" width="24" height="24" rx="12" fill="#1F1E1D" fill-opacity="0.15"/>
+<path d="M9.20117 15L15.2012 9" stroke="#6F6D6A" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M9.20117 9L15.2012 15" stroke="#6F6D6A" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/web/pages/[[...slug]].tsx
+++ b/web/pages/[[...slug]].tsx
@@ -8,6 +8,7 @@ import ConferenceHeader from '../components/ConferenceHeader';
 import NavBlock from '../components/NavBlock';
 import Footer from '../components/Footer';
 import { Slug } from '../types/Slug';
+import { mainEventId } from '../util/entityPaths';
 
 const QUERY = groq`
   {
@@ -43,6 +44,10 @@ const QUERY = groq`
           },
           _type != 'reference' => @ {
             ...,
+            _type == "ticketsSection" => {
+              ...,
+              "tickets": *[_id == "${mainEventId}"][0].tickets[]->
+            },
             content[] {
               ...,
               reference->,

--- a/web/styles/variables.css
+++ b/web/styles/variables.css
@@ -4,6 +4,7 @@
   --color-brand-white: #ffffff;
   --color-brand-yellow: #fff17e;
   --color-brand-yellow-light: #fff8e4;
+  --color-material-gray-600: rgba(31, 30, 29, 0.65);
   --color-sanity-blue: #2962ff;
   --color-ui-gray-600: #6f6d6a;
   --color-ui-gray-500: #a0a09c;
@@ -11,7 +12,10 @@
   --color-ui-gray-100: #f4f3ef;
   --font-body-base: 400 18px/25px 'Inter', sans-serif;
   --font-body-base-medium: 500 18px/25px 'Inter', sans-serif;
+  --font-body-large-bold: 700 20px/30px 'Inter', sans-serif;
   --font-body-large-medium: 500 20px/30px 'Inter', sans-serif;
+  --font-body-small-bold: 700 16px/22px 'Inter', sans-serif;
+  --font-body-small-medium: 500 16px/22px 'Inter', sans-serif;
   --font-body-xl-medium: 500 24px/33px 'Inter', sans-serif;
   --font-display-2xl: 700 96px/92.16px 'National 2 Narrow', sans-serif;
   --font-display-base: 700 40px/39px 'National 2 Narrow', sans-serif;
@@ -26,6 +30,7 @@
   --grid-medium-gutter: 32px; /* These could be set in @media if we drop IE11 */
   --grid-medium-half-gutter: 16px;
   --grid-width: 1520px;
+  --letter-spacing-body-small: -0.011em;
   --letter-spacing-body-base: -0.014em;
   --letter-spacing-body-large: -0.017em;
   --letter-spacing-body-xl: -0.019em;

--- a/web/types/Ticket.ts
+++ b/web/types/Ticket.ts
@@ -1,0 +1,6 @@
+export type Ticket = {
+  _id: string;
+  type: string;
+  price: number;
+  included: ['workshop', 'recordings'];
+};

--- a/web/util/entityPaths.ts
+++ b/web/util/entityPaths.ts
@@ -5,6 +5,8 @@ import { Sponsor } from '../types/Sponsor';
 
 type Entity = Person | Session | Venue | Sponsor;
 
+export const mainEventId = 'aad77280-6394-4090-afad-1c0f2a0416c6';
+
 export const getEntityPath = (entity: Entity) => {
   if (!entity.slug?.current) {
     return '#';


### PR DESCRIPTION
# Tickets.tsx: Support `ticketsSection` type section in [[...slug]].tsx

## Intent

Just like for "Venue" (`venueSection`) and "Sponsor" (`sponsorsSection`), fetch "Tickets" when encountering a `ticketsSection` and pass those along to the associated component. However, unlike the two former entities, tickets are fetched from the "Structured Content 2022" event, which holds the correct ordering. (I will fix querying sponsors and venues from this event too, in a separate PR.) 

## Testing this PR

1. Verify that a pricing table looking sort-of-like the one in the Figma sketches is rendered when viewing [/registration-info](https://structured-content-2022-web-bsoi970wa.sanity.build/registration-info), and that it looks sort-of-right when shrinking viewport to sub-768px width.
