### PR TITLE
Fetch Venues from conference event

### DIFF
--- a/web/components/Sponsor/Sponsor.module.css
+++ b/web/components/Sponsor/Sponsor.module.css
@@ -12,8 +12,8 @@
   height: 88px;
 }
 
-.sponsor.gold,
-.sponsor.silver {
+.sponsor.partner,
+.sponsor.community {
   width: 128px;
   height: 60px;
 }
@@ -29,7 +29,7 @@
     height: 130px;
   }
 
-  .sponsor.gold {
+  .sponsor.partner {
     width: 192px;
     height: 88px;
   }

--- a/web/components/Sponsor/Sponsor.tsx
+++ b/web/components/Sponsor/Sponsor.tsx
@@ -1,7 +1,7 @@
+import clsx from 'clsx';
 import { Sponsor as TSponsor, SponsorLevel } from '../../types/Sponsor';
 import { imageUrlFor } from '../../lib/sanity';
 import styles from './Sponsor.module.css';
-import clsx from 'clsx';
 
 interface SponsorProps {
   sponsor: TSponsor;
@@ -21,15 +21,15 @@ const imgDimensions: {
     height: Math.round(130 * assumedScaleFactor),
     className: styles.premier,
   },
-  Gold: {
+  Partner: {
     width: Math.round(192 * assumedScaleFactor),
     height: Math.round(88 * assumedScaleFactor),
-    className: styles.gold,
+    className: styles.partner,
   },
-  Silver: {
+  Community: {
     width: Math.round(128 * assumedScaleFactor),
     height: Math.round(60 * assumedScaleFactor),
-    className: styles.silver,
+    className: styles.community,
   },
 };
 
@@ -40,7 +40,7 @@ export const Sponsor = ({
     title,
   },
 }: SponsorProps) => {
-  const dimension = imgDimensions[type] || imgDimensions.Silver;
+  const dimension = imgDimensions[type] || imgDimensions.Community;
   const src = imageUrlFor(image)
     .auto('format')
     .bg('fff')

--- a/web/components/Sponsors/Sponsors.tsx
+++ b/web/components/Sponsors/Sponsors.tsx
@@ -19,14 +19,14 @@ const groupBySponsorLevel = (
     },
     {
       Premier: [],
-      Gold: [],
-      Silver: [],
+      Partner: [],
+      Community: [],
     }
   );
 
 export const Sponsors = ({ sponsors }: SponsorsProps) => {
   const groupedSponsors = groupBySponsorLevel(sponsors);
-  const levels: SponsorLevel[] = ['Premier', 'Gold', 'Silver'];
+  const levels: SponsorLevel[] = ['Premier', 'Partner', 'Community'];
   return (
     <GridWrapper>
       {levels.map((level) => (

--- a/web/components/TextBlock/QuestionAndAnswerCollection/QuestionAndAnswerCollection.tsx
+++ b/web/components/TextBlock/QuestionAndAnswerCollection/QuestionAndAnswerCollection.tsx
@@ -1,11 +1,9 @@
 import Heading from '../../Heading';
 import Block from '../Block';
-import GridWrapper from "../../GridWrapper";
+import GridWrapper from '../../GridWrapper';
 import styles from './QuestionAndAnswerCollection.module.css';
 
-export const QuestionAndAnswerCollection = ({
-  value: { questions },
-}) => (
+export const QuestionAndAnswerCollection = ({ value: { questions } }) => (
   <GridWrapper>
     {questions.map(({ _key, question, answer }) => (
       <div key={_key} className={styles.question}>

--- a/web/pages/[[...slug]].tsx
+++ b/web/pages/[[...slug]].tsx
@@ -8,6 +8,7 @@ import ConferenceHeader from '../components/ConferenceHeader';
 import NavBlock from '../components/NavBlock';
 import Footer from '../components/Footer';
 import { Slug } from '../types/Slug';
+import { mainEventId } from "../util/entityPaths";
 
 const QUERY = groq`
   {
@@ -32,7 +33,7 @@ const QUERY = groq`
               },
               _type == "venuesSection" => {
                 ...,
-                "venues": *[_type == "venue"]
+                "venues": *[_id == "${mainEventId}"][0].venues[]->,
               },
               content[] {
                 ...,

--- a/web/pages/[[...slug]].tsx
+++ b/web/pages/[[...slug]].tsx
@@ -8,7 +8,7 @@ import ConferenceHeader from '../components/ConferenceHeader';
 import NavBlock from '../components/NavBlock';
 import Footer from '../components/Footer';
 import { Slug } from '../types/Slug';
-import { mainEventId } from "../util/entityPaths";
+import { mainEventId } from '../util/entityPaths';
 
 const QUERY = groq`
   {

--- a/web/types/Sponsor.ts
+++ b/web/types/Sponsor.ts
@@ -1,6 +1,6 @@
 import { Slug } from './Slug';
 
-export type SponsorLevel = 'Silver' | 'Gold' | 'Premier';
+export type SponsorLevel = 'Community' | 'Partner' | 'Premier';
 
 export type Sponsor = {
   _id: string;

--- a/web/util/entityPaths.ts
+++ b/web/util/entityPaths.ts
@@ -5,6 +5,8 @@ import { Sponsor } from '../types/Sponsor';
 
 type Entity = Person | Session | Venue | Sponsor;
 
+export const mainEventId = 'aad77280-6394-4090-afad-1c0f2a0416c6';
+
 export const getEntityPath = (entity: Entity) => {
   if (!entity.slug?.current) {
     return '#';


### PR DESCRIPTION
# Fetch Venues from conference event

## Intent
- Fetch Venues from "Structured Content 2022 Conference" event
- Update `SponsorLevel` type with updated sponsor "level" names, update related usages

## Description

I wanted to also fetch Sponsors from the event, but that association gave me the impression of being a WIP in Studio, so I'm holding off on that. Instead I merely updated the `SponsorLevel` type with the new terms used in Studio.

## Testing this PR

- Verify that all the sponsor "levels" are once again shown in the [front page](https://structured-content-2022-web-ls10l9w7h.sanity.build/), and that the `VenueNames` component still displays all the venue names correctly.