### PR TITLE
Figure.tsx: support 'figure' component in TextBlock.tsx

### DIFF
--- a/web/components/TextBlock/Figure/Figure.module.css
+++ b/web/components/TextBlock/Figure/Figure.module.css
@@ -1,0 +1,3 @@
+.container {
+  text-align: center;
+}

--- a/web/components/TextBlock/Figure/Figure.tsx
+++ b/web/components/TextBlock/Figure/Figure.tsx
@@ -1,0 +1,28 @@
+import { PortableTextComponentProps } from '@portabletext/react';
+import { imageUrlFor } from '../../../lib/sanity';
+import GridWrapper from '../../GridWrapper';
+import styles from './Figure.module.css';
+
+type FigureProps = {
+  alt: string;
+  asset: {
+    _ref: string;
+    _type: 'reference';
+  };
+  _key: string;
+  _type: 'figure';
+};
+
+export const Figure = ({
+  value: { asset, alt },
+}: PortableTextComponentProps<FigureProps>) => (
+  <GridWrapper>
+    <div className={styles.container}>
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img
+        src={imageUrlFor(asset).width(894).ignoreImageParams().url()}
+        alt={alt}
+      />
+    </div>
+  </GridWrapper>
+);

--- a/web/components/TextBlock/Figure/index.ts
+++ b/web/components/TextBlock/Figure/index.ts
@@ -1,0 +1,1 @@
+export { Figure as default } from './Figure';

--- a/web/components/TextBlock/TextBlock/TextBlock.tsx
+++ b/web/components/TextBlock/TextBlock/TextBlock.tsx
@@ -14,6 +14,7 @@ import SimpleCallToAction from '../SimpleCallToAction';
 import ConferenceUpdatesForm from '../../ConferenceUpdatesForm';
 import VenuesSection from '../VenuesSection';
 import SponsorsSection from '../SponsorsSection';
+import Figure from '../Figure';
 
 const components: Partial<PortableTextComponents> = {
   types: {
@@ -29,6 +30,7 @@ const components: Partial<PortableTextComponents> = {
     articleSection: RichText,
     venuesSection: VenuesSection,
     sponsorsSection: SponsorsSection,
+    figure: Figure,
   },
   marks: {
     bold: ({ children }) => <strong>{children}</strong>,

--- a/web/util/blocksToText.ts
+++ b/web/util/blocksToText.ts
@@ -1,8 +1,0 @@
-const blocksToText = (blocks = []) =>
-  blocks.map((block) =>
-    block._type !== 'block' || !block.children
-      ? ''
-      : block.children.map((child) => child.text).join('')
-  );
-
-export default blocksToText;


### PR DESCRIPTION
# Figure.tsx: support 'figure' component in TextBlock.tsx

## Intent 

`figure`-type component support for `TextBlock`.

## Description

I accidentally managed to push this on `staging`, then had to do a little dance to revert it and submit the changes as a PR again. Hope everything is right now.

## Testing this PR

Verify that the pie chart image in [/sponsorship-information](https://structured-content-2022-web-qw74fcds6.sanity.build/sponsorship-information) correctly renders.