### PR TITLE
Show VenueNames for /about

### DIFF
--- a/web/pages/[[...slug]].tsx
+++ b/web/pages/[[...slug]].tsx
@@ -44,6 +44,10 @@ const QUERY = groq`
           },
           _type != 'reference' => @ {
             ...,
+            _type == "venuesSection" => {
+              ...,
+              "venues": *[_id == "${mainEventId}"][0].venues[]->,
+            },
             content[] {
               ...,
               reference->,


### PR DESCRIPTION
# Show VenueNames for /about

## Intent

Show `<VenueNames />` in /about. 

## Description

The query in _[[...slug]].tsx_ is getting hairier by the minute.. There might also be a need to duplicate the other section special-casings (`sponsorsSection`, `simpleCallToAction` etc.) for non-reference-type sections too, if those turn out to also be allowed at the top level. A way to make the query more legible (preferably after the initial deadline) could be to extract the various components into string constants and compose the query using them.

## Testing this PR

Verify that the Venue names are listed under the "Get registration info" CTA in [/about](https://structured-content-2022-web-eegz9nlu3.sanity.build/about).