### PR TITLE
/registration-info: Tickets section structure update

### DIFF
--- a/web/components/TextBlock/Block/Block.tsx
+++ b/web/components/TextBlock/Block/Block.tsx
@@ -3,7 +3,7 @@ import Person from '../Person';
 import Venue from '../Venue';
 
 export const Block = ({ value }) =>
-  value.children.map((child, index) => {
+  value.children?.map((child, index) => {
     if (!child._key && child._type) {
       switch (child._type) {
         case 'richText':
@@ -19,4 +19,4 @@ export const Block = ({ value }) =>
     }
 
     return <span key={index}>{child.text}</span>;
-  });
+  }) || null;

--- a/web/components/TextBlock/Tickets/Tickets.module.css
+++ b/web/components/TextBlock/Tickets/Tickets.module.css
@@ -102,7 +102,7 @@
   background-color: var(--color-brand-yellow-light);
 }
 
-@media (-medium-up) {
+@media (--medium-up) {
   .sections {
     margin: 64px 0;
   }

--- a/web/components/TextBlock/Tickets/Tickets.module.css
+++ b/web/components/TextBlock/Tickets/Tickets.module.css
@@ -32,16 +32,12 @@
 }
 
 .priceList {
-  margin: 0;
+  margin: 24px 0 0 0;
 }
 
 .priceLabel,
 .description {
   color: var(--color-material-gray-600);
-}
-
-.description {
-  margin: 0 0 24px;
 }
 
 .price {

--- a/web/components/TextBlock/Tickets/Tickets.module.css
+++ b/web/components/TextBlock/Tickets/Tickets.module.css
@@ -17,6 +17,7 @@
   border-radius: 8px;
   font: inherit;
   text-align: left;
+  vertical-align: top;
 }
 
 .ticketInfo.inSections {
@@ -25,7 +26,7 @@
 }
 
 .name {
-  margin: 0 0 24px;
+  margin: 0 0 4px;
   font: var(--font-body-large-bold);
   letter-spacing: var(--font-body-large);
 }
@@ -34,14 +35,29 @@
   margin: 0;
 }
 
-.priceLabel {
+.priceLabel,
+.description {
   color: var(--color-material-gray-600);
 }
 
-.price {
-  margin: 0;
-  font: var(--font-body-small-bold);
+.description {
+  margin: 0 0 24px;
 }
+
+.price {
+  margin: 0 0 8px;
+  text-decoration: line-through;
+  color: var(--color-material-gray-600);
+  font: var(--font-body-small-medium);
+}
+
+.price:last-child {
+  text-decoration: none;
+  font: var(--font-body-small-bold);
+  color: var(--color-brand-black);
+  margin: 0;
+}
+
 
 .ticketFeatures {
   list-style-type: none;

--- a/web/components/TextBlock/Tickets/Tickets.module.css
+++ b/web/components/TextBlock/Tickets/Tickets.module.css
@@ -2,6 +2,8 @@
   display: none;
   width: 100%;
   border-spacing: 8px;
+  font: var(--font-body-small-medium);
+  letter-spacing: var(--letter-spacing-body-small);
   margin: 96px 0;
 }
 
@@ -44,7 +46,6 @@
   margin: 0 0 8px;
   text-decoration: line-through;
   color: var(--color-material-gray-600);
-  font: var(--font-body-small-medium);
 }
 
 .price:last-child {

--- a/web/components/TextBlock/Tickets/Tickets.module.css
+++ b/web/components/TextBlock/Tickets/Tickets.module.css
@@ -52,7 +52,7 @@
   margin: 0;
 }
 
-.currentPrice {
+.price.current {
   text-decoration: none;
   font: var(--font-body-small-bold);
   color: var(--color-brand-black);

--- a/web/components/TextBlock/Tickets/Tickets.module.css
+++ b/web/components/TextBlock/Tickets/Tickets.module.css
@@ -52,12 +52,14 @@
 }
 
 .price:last-child {
-  text-decoration: none;
-  font: var(--font-body-small-bold);
-  color: var(--color-brand-black);
   margin: 0;
 }
 
+.currentPrice {
+  text-decoration: none;
+  font: var(--font-body-small-bold);
+  color: var(--color-brand-black);
+}
 
 .ticketFeatures {
   list-style-type: none;

--- a/web/components/TextBlock/Tickets/Tickets.module.css
+++ b/web/components/TextBlock/Tickets/Tickets.module.css
@@ -54,7 +54,6 @@
 
 .price.current {
   text-decoration: none;
-  font: var(--font-body-small-bold);
   color: var(--color-brand-black);
 }
 

--- a/web/components/TextBlock/Tickets/Tickets.tsx
+++ b/web/components/TextBlock/Tickets/Tickets.tsx
@@ -7,6 +7,7 @@ import clsx from 'clsx';
 import { Fragment } from 'react';
 import Block from '../Block';
 import { compareAsc, parseISO } from 'date-fns';
+import { PortableText } from '@portabletext/react';
 
 interface TicketsProps {
   value: {
@@ -55,9 +56,7 @@ export const Tickets = ({ value: { type, tickets } }: TicketsProps) => {
                   <div className={styles.name}>{ticket.type}</div>
                   {ticket.description && (
                     <div className={styles.description}>
-                      {ticket.description.map((value) => (
-                        <Block key={value._key} value={value} />
-                      ))}
+                      <PortableText value={ticket.description} />
                     </div>
                   )}
                   <dl className={styles.priceList}>
@@ -137,9 +136,7 @@ export const Tickets = ({ value: { type, tickets } }: TicketsProps) => {
                 <h3 className={styles.name}>{ticket.type}</h3>
                 {ticket.description && (
                   <div className={styles.description}>
-                    {ticket.description.map((value) => (
-                      <Block key={value._key} value={value} />
-                    ))}
+                    <PortableText value={ticket.description} />
                   </div>
                 )}
                 <dl className={styles.priceList}>

--- a/web/components/TextBlock/Tickets/Tickets.tsx
+++ b/web/components/TextBlock/Tickets/Tickets.tsx
@@ -5,7 +5,6 @@ import crossIcon from '../../../images/cross.svg';
 import styles from './Tickets.module.css';
 import clsx from 'clsx';
 import { Fragment } from 'react';
-import Block from '../Block';
 import { compareAsc, parseISO } from 'date-fns';
 import { PortableText } from '@portabletext/react';
 

--- a/web/components/TextBlock/Tickets/Tickets.tsx
+++ b/web/components/TextBlock/Tickets/Tickets.tsx
@@ -53,11 +53,13 @@ export const Tickets = ({ value: { type, tickets } }: TicketsProps) => {
               return (
                 <th key={ticket._id} scope="col" className={styles.ticketInfo}>
                   <div className={styles.name}>{ticket.type}</div>
-                  <div className={styles.description}>
-                    {ticket.description?.map((value) => (
-                      <Block key={value._key} value={value} />
-                    ))}
-                  </div>
+                  {ticket.description && (
+                    <div className={styles.description}>
+                      {ticket.description.map((value) => (
+                        <Block key={value._key} value={value} />
+                      ))}
+                    </div>
+                  )}
                   <dl className={styles.priceList}>
                     {ticket.priceAndAvailability.map(
                       ({ _key, label, price }) => (
@@ -132,11 +134,13 @@ export const Tickets = ({ value: { type, tickets } }: TicketsProps) => {
             <section key={ticket._id}>
               <div className={clsx(styles.ticketInfo, styles.inSections)}>
                 <h3 className={styles.name}>{ticket.type}</h3>
-                <div className={styles.description}>
-                  {ticket.description?.map((value) => (
-                    <Block key={value._key} value={value} />
-                  ))}
-                </div>
+                {ticket.description && (
+                  <div className={styles.description}>
+                    {ticket.description.map((value) => (
+                      <Block key={value._key} value={value} />
+                    ))}
+                  </div>
+                )}
                 <dl className={styles.priceList}>
                   {ticket.priceAndAvailability.map(({ _key, label, price }) => (
                     <Fragment key={_key}>

--- a/web/components/TextBlock/Tickets/Tickets.tsx
+++ b/web/components/TextBlock/Tickets/Tickets.tsx
@@ -4,6 +4,8 @@ import checkmarkIcon from '../../../images/checkmark.svg';
 import crossIcon from '../../../images/cross.svg';
 import styles from './Tickets.module.css';
 import clsx from 'clsx';
+import { Fragment } from 'react';
+import Block from "../Block";
 
 interface TicketsProps {
   value: {
@@ -36,11 +38,18 @@ export const Tickets = ({ value: { type, tickets } }: TicketsProps) => {
             {tickets.map((ticket) => (
               <th key={ticket._id} scope="col" className={styles.ticketInfo}>
                 <div className={styles.name}>{ticket.type}</div>
+                <div className={styles.description}>
+                  {ticket.description?.map((value) => (
+                    <Block key={value._key} value={value} />
+                  ))}
+                </div>
                 <dl className={styles.priceList}>
-                  <dt className={styles.priceLabel}>Price</dt>
-                  <dd className={styles.price}>
-                    {ticket.price ? `$${ticket.price}` : 'Free'}
-                  </dd>
+                  {ticket.priceAndAvailability.map(({ _key, label, price }) => (
+                    <Fragment key={_key}>
+                      <dt className={styles.priceLabel}>Price {label ? `(${label})` : null}</dt>
+                      <dd className={clsx(styles.price, styles.currentPrice)}>{price ? `$${price}` : 'Free'}</dd>
+                    </Fragment>
+                  ))}
                 </dl>
               </th>
             ))}
@@ -94,11 +103,18 @@ export const Tickets = ({ value: { type, tickets } }: TicketsProps) => {
           <section key={ticket._id}>
             <div className={clsx(styles.ticketInfo, styles.inSections)}>
               <h3 className={styles.name}>{ticket.type}</h3>
+              <div className={styles.description}>
+                {ticket.description?.map((value) => (
+                  <Block key={value._key} value={value} />
+                ))}
+              </div>
               <dl className={styles.priceList}>
-                <dt className={styles.priceLabel}>Price</dt>
-                <dd className={styles.price}>
-                  {ticket.price ? `$${ticket.price}` : 'Free'}
-                </dd>
+                {ticket.priceAndAvailability.map(({ _key, label, price }) => (
+                  <Fragment key={_key}>
+                    <dt className={styles.priceLabel}>{label}</dt>
+                    <dd className={styles.price}>{price ? `$${price}` : 'Free'}</dd>
+                  </Fragment>
+                ))}
               </dl>
             </div>
             <ul className={styles.ticketFeatures}>

--- a/web/components/TextBlock/Tickets/Tickets.tsx
+++ b/web/components/TextBlock/Tickets/Tickets.tsx
@@ -67,14 +67,15 @@ export const Tickets = ({ value: { type, tickets } }: TicketsProps) => {
                           <dt className={styles.priceLabel}>
                             Price {label ? `(${label})` : null}
                           </dt>
-                          <dd
-                            className={clsx(
-                              styles.price,
-                              currentPrice._key == _key && styles.current
-                            )}
-                          >
-                            {price ? `$${price}` : 'Free'}
-                          </dd>
+                          {currentPrice._key == _key ? (
+                            <dd className={clsx(styles.price, styles.current)}>
+                              <strong>{price ? `$${price}` : 'Free'}</strong>
+                            </dd>
+                          ) : (
+                            <dd className={styles.price}>
+                              {price ? `$${price}` : 'Free'}
+                            </dd>
+                          )}
                         </Fragment>
                       )
                     )}
@@ -147,14 +148,15 @@ export const Tickets = ({ value: { type, tickets } }: TicketsProps) => {
                       <dt className={styles.priceLabel}>
                         Price {label ? `(${label})` : null}
                       </dt>
-                      <dd
-                        className={clsx(
-                          styles.price,
-                          currentPrice._key == _key && styles.current
-                        )}
-                      >
-                        {price ? `$${price}` : 'Free'}
-                      </dd>
+                      {currentPrice._key == _key ? (
+                        <dd className={clsx(styles.price, styles.current)}>
+                          <strong>{price ? `$${price}` : 'Free'}</strong>
+                        </dd>
+                      ) : (
+                        <dd className={styles.price}>
+                          {price ? `$${price}` : 'Free'}
+                        </dd>
+                      )}
                     </Fragment>
                   ))}
                 </dl>

--- a/web/components/TextBlock/Tickets/Tickets.tsx
+++ b/web/components/TextBlock/Tickets/Tickets.tsx
@@ -70,7 +70,7 @@ export const Tickets = ({ value: { type, tickets } }: TicketsProps) => {
                           <dd
                             className={clsx(
                               styles.price,
-                              currentPrice._key == _key && styles.currentPrice
+                              currentPrice._key == _key && styles.current
                             )}
                           >
                             {price ? `$${price}` : 'Free'}
@@ -150,7 +150,7 @@ export const Tickets = ({ value: { type, tickets } }: TicketsProps) => {
                       <dd
                         className={clsx(
                           styles.price,
-                          currentPrice._key == _key && styles.currentPrice
+                          currentPrice._key == _key && styles.current
                         )}
                       >
                         {price ? `$${price}` : 'Free'}

--- a/web/types/Ticket.ts
+++ b/web/types/Ticket.ts
@@ -1,4 +1,4 @@
-import { Section } from "./Section";
+import { Section } from './Section';
 
 export type Ticket = {
   _id: string;

--- a/web/types/Ticket.ts
+++ b/web/types/Ticket.ts
@@ -1,6 +1,16 @@
+import { Section } from "./Section";
+
 export type Ticket = {
   _id: string;
+  _type: 'ticket';
+  description?: Section[];
+  included: string[];
+  priceAndAvailability: {
+    _key: string;
+    _type: 'available';
+    from: string;
+    label: string;
+    price: number;
+  }[];
   type: string;
-  price: number;
-  included: ['workshop', 'recordings'];
 };


### PR DESCRIPTION
# /registration-info: Tickets section structure update

## Intent 

Updates the Tickets section component to handle the changes introduced in tonight's Sanity model updates. 

## Description

The logic for figuring out which price is the current was copied from _/studio/schemas/documents/ticket.ts_ (`currentPrice`)

## Testing this PR

- Verify that the table under "Event Pricing" in [/registration-info](https://structured-content-2022-web-jooo8mk6k.sanity.build/registration-info) looks like the Figma sketches, presenting all [Ticket(s) fields available in the Studio](http://localhost:3333/desk/structuredContent2022;58dc88bb-2e29-4de1-8e91-d7755b0afc69%2Ctype%3Dticket%2CparentRefPath%3Dtickets%5B_key%3D%3D%22faac203288c0%22%5D).
- Change the "from" date on the non-"Early bird" "Price and availability" section of the "In-person" Ticket type to a date that's already passed, "Publish" and refresh your browser, and verify that the "Early bird" price for is no longer highlighted, with the 700$ ticket now being the highlighted option. Revert your changes in the Studio.
- [This Shortcut story](https://app.shortcut.com/sanity-io/story/15041/front-end-present-latest-ticket-info-fields-from-studio) says that the ticket prices are not being updated. Verify that this is (no longer?) the case; that updating everything Ticket-related (or at least the price?) works as expected.

@oyvind-stenhaug Commit your CSS and markup changes (if any) to this branch or in a separate PR, whatever is your preference. :slightly_smiling_face: 