### PR TITLE
Change hardcoded header nav items

### DIFF
--- a/web/components/Nav/Nav.module.css
+++ b/web/components/Nav/Nav.module.css
@@ -21,6 +21,7 @@
   margin: 0;
   list-style: none;
   display: flex;
+  flex-wrap: wrap;
 }
 
 .menuButtonWrapper,

--- a/web/components/Nav/Nav.tsx
+++ b/web/components/Nav/Nav.tsx
@@ -72,9 +72,16 @@ export const Nav = ({ onFrontPage }: NavProps) => {
               </Link>
             </li>
             <li>
-              <Link href="/speakers">
+              <Link href="/sponsorship-information">
                 <a className={styles.link} onClick={closeMenu}>
-                  Speakers
+                  Sponsorship
+                </a>
+              </Link>
+            </li>
+            <li>
+              <Link href="/venues">
+                <a className={styles.link} onClick={closeMenu}>
+                  Venues
                 </a>
               </Link>
             </li>


### PR DESCRIPTION
# Change hardcoded header nav items

## Intent

As specified by Celine: Update the header nav to be more like the primary nav in Sanity Studio, but keeping it hardcoded. Remove "Speakers" item since that page is out of scope for initial launch (the /speakers URL is 404).

## Description

Was a bit concerned that the addition of more/longer strings here would cause us to run out of space, but it looks like we're still good even on narrow "tablet"-like viewports. Nevertheless I added a CSS declaration to enable the menu to wrap if necessary. Not defined by the design but it's a better failure mode than overflowing the viewport which is what would otherwise happen (the Tickets button would eventually be inaccessible, and so on)

## Testing this PR
1. Open the [About page](https://structured-content-2022-web-git-change-hardcoded-header-bed6ae.sanity.build/about) on a wide-ish screen (viewport width >= 768px)
2. Verify that the header menu in the top center is showing "Program Sponsorship Venues About"