### PR TITLE
Adjust Figure frontend

### DIFF
--- a/web/components/TextBlock/Figure/Figure.module.css
+++ b/web/components/TextBlock/Figure/Figure.module.css
@@ -2,3 +2,7 @@
   margin: 0;
   text-align: center;
 }
+
+.image {
+  max-width: 100%;
+}

--- a/web/components/TextBlock/Figure/Figure.module.css
+++ b/web/components/TextBlock/Figure/Figure.module.css
@@ -1,3 +1,4 @@
 .container {
+  margin: 0;
   text-align: center;
 }

--- a/web/components/TextBlock/Figure/Figure.tsx
+++ b/web/components/TextBlock/Figure/Figure.tsx
@@ -22,6 +22,7 @@ export const Figure = ({
       <img
         src={imageUrlFor(asset).width(894).ignoreImageParams().url()}
         alt={alt}
+        className={styles.image}
       />
     </figure>
   </GridWrapper>

--- a/web/components/TextBlock/Figure/Figure.tsx
+++ b/web/components/TextBlock/Figure/Figure.tsx
@@ -17,12 +17,12 @@ export const Figure = ({
   value: { asset, alt },
 }: PortableTextComponentProps<FigureProps>) => (
   <GridWrapper>
-    <div className={styles.container}>
+    <figure className={styles.container}>
       {/* eslint-disable-next-line @next/next/no-img-element */}
       <img
         src={imageUrlFor(asset).width(894).ignoreImageParams().url()}
         alt={alt}
       />
-    </div>
+    </figure>
   </GridWrapper>
 );


### PR DESCRIPTION
# Adjust Figure frontend

## Intent

Add some basic adjustments to the Figure component's markup/styling. The Figma sketch for this section type is not yet approved, so won't spend much time on it, this is just intended to make some ad-hoc changes to ensure it's OK in the meantime.

## Description

Mainly this just consists of a `max-width` to stop the image from horizontally overflowing the viewport.

I also used the `figure` element. I'm thinking this is probably the right thing here, although it somewhat depends on usage.

Ideally we would also have `width` and `height` attributes, but this is already filed as an issue on its own. (I have now also filed it in Shortcut, it should be in the "Next" column.)

## Testing this PR
1. Open https://structured-content-2022-web-git-adjust-figure-frontend.sanity.build/sponsorship-information
2. Scroll down to the pie chart
3. Shrink the window width to <600px and verify that the image is scaled down, and doesn't cause a horizontal scrollbar to appear