### PR TITLE
Header menu selected state

### DIFF
--- a/web/components/Nav/Nav.module.css
+++ b/web/components/Nav/Nav.module.css
@@ -134,6 +134,12 @@
   }
 }
 
+@media (--medium-up) {
+  .link.current {
+    text-decoration: underline;
+  }
+}
+
 @media (--large-up) {
   .menuContents {
     padding: 24px 0;

--- a/web/components/Nav/Nav.tsx
+++ b/web/components/Nav/Nav.tsx
@@ -21,6 +21,22 @@ export const Nav = ({ onFrontPage }: NavProps) => {
   const toggleMenu = () => setMenuOpened(!menuOpened);
   const closeMenu = () => setMenuOpened(false);
 
+  const BasicMenuItem = ({
+    urlPath,
+    label,
+  }: {
+    urlPath: string;
+    label: string;
+  }) => (
+    <li>
+      <Link href={urlPath}>
+        <a className={styles.link} onClick={closeMenu}>
+          {label}
+        </a>
+      </Link>
+    </li>
+  );
+
   return (
     <nav className={clsx(styles.nav, onFrontPage && styles.onFrontPage)}>
       <GridWrapper>
@@ -64,34 +80,13 @@ export const Nav = ({ onFrontPage }: NavProps) => {
                 </a>
               </Link>
             </li>
-            <li>
-              <Link href="/program">
-                <a className={styles.link} onClick={closeMenu}>
-                  Program
-                </a>
-              </Link>
-            </li>
-            <li>
-              <Link href="/sponsorship-information">
-                <a className={styles.link} onClick={closeMenu}>
-                  Sponsorship
-                </a>
-              </Link>
-            </li>
-            <li>
-              <Link href="/venues">
-                <a className={styles.link} onClick={closeMenu}>
-                  Venues
-                </a>
-              </Link>
-            </li>
-            <li>
-              <Link href="/about">
-                <a className={styles.link} onClick={closeMenu}>
-                  About
-                </a>
-              </Link>
-            </li>
+            <BasicMenuItem urlPath="/program" label="Program" />
+            <BasicMenuItem
+              urlPath="/sponsorship-information"
+              label="Sponsorship"
+            />
+            <BasicMenuItem urlPath="/venues" label="Venues" />
+            <BasicMenuItem urlPath="/about" label="About" />
           </ul>
           <div className={styles.ticketButton}>
             <ButtonLink url="/tickets" text="Tickets" />

--- a/web/components/Nav/Nav.tsx
+++ b/web/components/Nav/Nav.tsx
@@ -8,9 +8,10 @@ import styles from './Nav.module.css';
 
 interface NavProps {
   onFrontPage: boolean;
+  currentPath: string;
 }
 
-export const Nav = ({ onFrontPage }: NavProps) => {
+export const Nav = ({ onFrontPage, currentPath }: NavProps) => {
   const [menuOpened, setMenuOpened] = useState(false);
   const contentsId = 'nav-menu-contents';
 
@@ -27,15 +28,21 @@ export const Nav = ({ onFrontPage }: NavProps) => {
   }: {
     urlPath: string;
     label: string;
-  }) => (
-    <li>
-      <Link href={urlPath}>
-        <a className={styles.link} onClick={closeMenu}>
-          {label}
-        </a>
-      </Link>
-    </li>
-  );
+  }) => {
+    const isCurrentPage = urlPath === currentPath;
+    return (
+      <li>
+        <Link href={urlPath}>
+          <a
+            className={clsx(styles.link, isCurrentPage && styles.current)}
+            onClick={closeMenu}
+          >
+            {label}
+          </a>
+        </Link>
+      </li>
+    );
+  };
 
   return (
     <nav className={clsx(styles.nav, onFrontPage && styles.onFrontPage)}>

--- a/web/components/Nav/Nav.tsx
+++ b/web/components/Nav/Nav.tsx
@@ -28,21 +28,21 @@ export const Nav = ({ onFrontPage, currentPath }: NavProps) => {
   }: {
     urlPath: string;
     label: string;
-  }) => {
-    const isCurrentPage = urlPath === currentPath;
-    return (
-      <li>
-        <Link href={urlPath}>
-          <a
-            className={clsx(styles.link, isCurrentPage && styles.current)}
-            onClick={closeMenu}
-          >
-            {label}
-          </a>
-        </Link>
-      </li>
-    );
-  };
+  }) => (
+    <li>
+      <Link href={urlPath}>
+        <a
+          className={clsx(
+            styles.link,
+            urlPath === currentPath && styles.current
+          )}
+          onClick={closeMenu}
+        >
+          {label}
+        </a>
+      </Link>
+    </li>
+  );
 
   return (
     <nav className={clsx(styles.nav, onFrontPage && styles.onFrontPage)}>

--- a/web/pages/_app.tsx
+++ b/web/pages/_app.tsx
@@ -38,7 +38,8 @@ function MyApp({ Component, pageProps, router }) {
     return () => window.removeEventListener('scroll', onScroll);
   }, [scrollTop]);
 
-  const isFrontPage = router.asPath === '/';
+  const currentPath = router.asPath;
+  const isFrontPage = currentPath === '/';
   const scrolledFarEnough = scrollTop > scrollPositionTriggeringFrontPageMenu;
   const headerClasses = clsx(
     styles.header,
@@ -49,7 +50,7 @@ function MyApp({ Component, pageProps, router }) {
   return (
     <>
       <header className={headerClasses}>
-        <Nav onFrontPage={isFrontPage} />
+        <Nav onFrontPage={isFrontPage} currentPath={currentPath} />
       </header>
       <Component {...pageProps} />
       <div className={styles.cookieConsent}>


### PR DESCRIPTION
# Header menu selected state

## Intent

Underline regular menu items in the tablet/desktop header menu when they are "selected" i.e. match the current page ([Shortcut story 15079](https://app.shortcut.com/sanity-io/story/15079/selected-states-for-main-navs-underline))

## Description

Underline is also used as a hover style here. Got a clarification from Celine in Slack that it's OK to keep both behaviors (so I would consider it expected that a menu item is underlined if it is hovered _and/or_ its href matches the currently opened page). Moreover that this "selected" state is not used for the mobile menu (which doesn't look like a menu bar).

With the introduction of the `currentPath` prop on `Nav`, the `onFrontPage` prop looks somewhat redundant. I chose to keep it because—as currently written—the `MyApp` component (`_app.tsx`) needs to know that boolean itself anyway.

## Testing this PR
1. Open the [About page](https://structured-content-2022-web-git-header-menu-selected-state.sanity.build/about)
2. Make sure the window is wide enough that the header menu bar is displayed at the top of the screen, and verify that "About" in that menu is underlined
3. Click "Sponsorship" in the menu and verify that this word is now underlined (even when not hovered)