### PR TITLE
Redirect /tickets to Sanity-defined destination

### DIFF
--- a/web/components/Nav/Nav.tsx
+++ b/web/components/Nav/Nav.tsx
@@ -8,9 +8,10 @@ import styles from './Nav.module.css';
 
 interface NavProps {
   onFrontPage: boolean;
+  ticketsUrl: string;
 }
 
-export const Nav = ({ onFrontPage }: NavProps) => {
+export const Nav = ({ onFrontPage, ticketsUrl }: NavProps) => {
   const [menuOpened, setMenuOpened] = useState(false);
   const contentsId = 'nav-menu-contents';
 
@@ -58,7 +59,7 @@ export const Nav = ({ onFrontPage }: NavProps) => {
           </Link>
           <ul className={clsx(styles.items, !menuOpened && styles.menuClosed)}>
             <li className={styles.ticketItem}>
-              <Link href="/tickets">
+              <Link href={ticketsUrl}>
                 <a className={styles.link} onClick={closeMenu}>
                   Tickets
                 </a>
@@ -94,7 +95,7 @@ export const Nav = ({ onFrontPage }: NavProps) => {
             </li>
           </ul>
           <div className={styles.ticketButton}>
-            <ButtonLink url="/tickets" text="Tickets" />
+            <ButtonLink url={ticketsUrl} text="Tickets" />
           </div>
         </div>
       </GridWrapper>

--- a/web/components/NavBlock/NavBlock.tsx
+++ b/web/components/NavBlock/NavBlock.tsx
@@ -21,7 +21,11 @@ const FakeItem = ({ divider, mobile, tablet, desktop }: FakeItemProps) => (
   />
 );
 
-export const NavBlock = () => (
+interface NavBlockProps {
+  ticketsUrl: string;
+}
+
+export const NavBlock = ({ ticketsUrl }: NavBlockProps) => (
   <nav className={styles.nav}>
     <ul className={styles.list}>
       <FakeItem mobile />
@@ -60,7 +64,7 @@ export const NavBlock = () => (
       <FakeItem divider mobile />
 
       <li className={styles.item}>
-        <Link href="/tickets">
+        <Link href={ticketsUrl}>
           <a className={styles.link}>Early-bird tickets</a>
         </Link>
       </li>

--- a/web/lib/config.js
+++ b/web/lib/config.js
@@ -1,9 +1,8 @@
-import { ProjectConfig } from 'next-sanity';
-
-export const projectConfig: ProjectConfig = {
+const projectConfig = {
   projectId: '33zsuc7i',
   dataset: 'production',
 };
+
 const config = {
   sanity: {
     baseConfig: {
@@ -13,4 +12,7 @@ const config = {
   },
 };
 
-export default config;
+module.exports = {
+  default: config,
+  projectConfig,
+};

--- a/web/lib/sanity.server.js
+++ b/web/lib/sanity.server.js
@@ -1,0 +1,6 @@
+const sanityClient = require('@sanity/client');
+const { default: config } = require('./config');
+
+const mainClient = sanityClient({ ...config.sanity.baseConfig });
+
+module.exports = mainClient;

--- a/web/lib/sanity.server.ts
+++ b/web/lib/sanity.server.ts
@@ -1,6 +1,0 @@
-import sanityClient from '@sanity/client';
-import config from './config';
-
-const mainClient = sanityClient({ ...config.sanity.baseConfig });
-
-export default mainClient;

--- a/web/next.config.js
+++ b/web/next.config.js
@@ -7,15 +7,17 @@ module.exports = {
   },
   async redirects() {
     // ".microcopy[key == "mainCta"]" filtering does not work, so we have to filter server side
-    const microCopy = await client.fetch(`*[_id == "aad77280-6394-4090-afad-1c0f2a0416c6"][0].microcopy[]`);
+    const microCopy = await client.fetch(
+      `*[_id == "aad77280-6394-4090-afad-1c0f2a0416c6"][0].microcopy[]`
+    );
     if (!Array.isArray(microCopy) || !microCopy.length) {
-      console.error("Could not find 'microcopy' attribute of main event!")
+      console.error("Could not find 'microcopy' attribute of main event!");
       return [];
     }
 
-    const mainCta = microCopy.find(microCopy => microCopy.key === 'mainCta');
+    const mainCta = microCopy.find((microCopy) => microCopy.key === 'mainCta');
     if (!mainCta?.action) {
-      console.error("Could not find 'mainCta' element in microcopy array!")
+      console.error("Could not find 'mainCta' element in microcopy array!");
       return [];
     }
 
@@ -26,6 +28,6 @@ module.exports = {
         destination: mainCta.action,
         permanent: true,
       },
-    ]
+    ];
   },
 };

--- a/web/next.config.js
+++ b/web/next.config.js
@@ -1,6 +1,31 @@
+const client = require('./lib/sanity.server');
+
 module.exports = {
   reactStrictMode: true,
   images: {
     domains: ['cdn.sanity.io'],
+  },
+  async redirects() {
+    // ".microcopy[key == "mainCta"]" filtering does not work, so we have to filter server side
+    const microCopy = await client.fetch(`*[_id == "aad77280-6394-4090-afad-1c0f2a0416c6"][0].microcopy[]`);
+    if (!Array.isArray(microCopy) || !microCopy.length) {
+      console.error("Could not find 'microcopy' attribute of main event!")
+      return [];
+    }
+
+    const mainCta = microCopy.find(microCopy => microCopy.key === 'mainCta');
+    if (!mainCta?.action) {
+      console.error("Could not find 'mainCta' element in microcopy array!")
+      return [];
+    }
+
+    console.log(`Redirecting /tickets to ${mainCta.action}`);
+    return [
+      {
+        source: '/tickets',
+        destination: mainCta.action,
+        permanent: true,
+      },
+    ]
   },
 };

--- a/web/pages/[[...slug]].tsx
+++ b/web/pages/[[...slug]].tsx
@@ -1,18 +1,18 @@
-import clsx from "clsx";
+import clsx from 'clsx';
 import { groq } from 'next-sanity';
-import { useEffect, useState } from "react";
+import { useEffect, useState } from 'react';
 import Hero from '../components/Hero';
 import TextBlock from '../components/TextBlock';
 import GridWrapper from '../components/GridWrapper';
 import ConferenceHeader from '../components/ConferenceHeader';
 import NavBlock from '../components/NavBlock';
 import Footer from '../components/Footer';
-import Nav from "../components/Nav";
+import Nav from '../components/Nav';
 import client from '../lib/sanity.server';
 import { Slug } from '../types/Slug';
 import { Section } from '../types/Section';
 import { mainEventId } from '../util/entityPaths';
-import styles from "./app.module.css";
+import styles from './app.module.css';
 
 const QUERY = groq`
   {
@@ -121,10 +121,10 @@ const Route = ({
   );
 
   /* This is a hack. What we really want is to enable the menu once we've
- * scrolled past the top logo on the front page. Probably a better way would
- * be to give the page a callback so it can use IntersectionObserver and
- * notify us when the right elements have appeared/disappeared from view.
- */
+   * scrolled past the top logo on the front page. Probably a better way would
+   * be to give the page a callback so it can use IntersectionObserver and
+   * notify us when the right elements have appeared/disappeared from view.
+   */
   const scrollPositionTriggeringFrontPageMenu = 420;
 
   useEffect(() => {
@@ -144,11 +144,10 @@ const Route = ({
     isFrontPage && scrolledFarEnough && styles.onScrolledFrontPage
   );
 
-
   return (
     <>
       <header className={headerClasses}>
-        <Nav onFrontPage={isFrontPage} ticketsUrl={ticketsUrl}/>
+        <Nav onFrontPage={isFrontPage} ticketsUrl={ticketsUrl} />
       </header>
       <main>
         {slug === '/' ? (
@@ -159,14 +158,14 @@ const Route = ({
               endDate={endDate}
               description={description}
             />
-            <NavBlock ticketsUrl={ticketsUrl}/>
+            <NavBlock ticketsUrl={ticketsUrl} />
           </GridWrapper>
         ) : (
-          <Hero heading={name}/>
+          <Hero heading={name} />
         )}
-        <TextBlock value={sections}/>
+        <TextBlock value={sections} />
       </main>
-      <Footer links={footer.links}/>
+      <Footer links={footer.links} />
     </>
   );
 };

--- a/web/pages/_app.tsx
+++ b/web/pages/_app.tsx
@@ -1,17 +1,11 @@
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { getCookieConsentValue } from 'react-cookie-consent';
 import TagManager from 'react-gtm-module';
-import clsx from 'clsx';
 import CookieConsent from '../components/CookieConsent';
-import Nav from '../components/Nav';
 import '../styles/globals.css';
 import styles from './app.module.css';
 
-function MyApp({ Component, pageProps, router }) {
-  const [scrollTop, setScrollTop] = useState(
-    typeof document !== 'undefined' ? document.documentElement.scrollTop : 0
-  );
-
+function MyApp({ Component, pageProps }) {
   useEffect(() => {
     const hasConsent = getCookieConsentValue();
     if (
@@ -22,35 +16,8 @@ function MyApp({ Component, pageProps, router }) {
     }
   }, []);
 
-  /* This is a hack. What we really want is to enable the menu once we've
-   * scrolled past the top logo on the front page. Probably a better way would
-   * be to give the page a callback so it can use IntersectionObserver and
-   * notify us when the right elements have appeared/disappeared from view.
-   */
-  const scrollPositionTriggeringFrontPageMenu = 420;
-
-  useEffect(() => {
-    const onScroll = (e) => {
-      setScrollTop(e.target.documentElement.scrollTop);
-    };
-    window.addEventListener('scroll', onScroll);
-
-    return () => window.removeEventListener('scroll', onScroll);
-  }, [scrollTop]);
-
-  const isFrontPage = router.asPath === '/';
-  const scrolledFarEnough = scrollTop > scrollPositionTriggeringFrontPageMenu;
-  const headerClasses = clsx(
-    styles.header,
-    isFrontPage && styles.onFrontPage,
-    isFrontPage && scrolledFarEnough && styles.onScrolledFrontPage
-  );
-
   return (
     <>
-      <header className={headerClasses}>
-        <Nav onFrontPage={isFrontPage} />
-      </header>
       <Component {...pageProps} />
       <div className={styles.cookieConsent}>
         <CookieConsent />


### PR DESCRIPTION
# Redirect /tickets to Sanity-defined destination

## Intent

Adds server- and client-side redirects for the `/tickets` path. The redirect points to a source defined in Sanity.

## Testing this PR

1. Verify that accessing /tickets directly (i.e. typing in [http://localhost:3000/tickets](http://localhost:3000/tickets) directly in your browser's URL bar and pressing enter) redirects you to the destination specified in Sanity (currently https://hopin.com)
2. Verify that clicking the "Tickets ->" link in the `<Nav />` and the "Early-bird Tickets" item in the `<NavBlock />` redirects you to the same place