### PR TITLE
Stop setting smooth scroll behavior for viewport

### DIFF
--- a/web/styles/globals.css
+++ b/web/styles/globals.css
@@ -27,10 +27,6 @@
   outline: 2px solid var(--color-brand-black);
 }
 
-html {
-  scroll-behavior: smooth;
-}
-
 body {
   margin: 0;
   font: var(--font-body-base);


### PR DESCRIPTION
# Disable smooth scroll

## Intent

Disable smooth scrolling of the top-level viewport, because Next's Link behavior doesn't play well with this. See [Shortcut story](https://app.shortcut.com/sanity-io/story/15121/animation-when-clicking-on-a-main-nav-link-the-page-sometimes-scrolls-down-up-is-this-done-purposely)

## Description

This CSS declaration was "inherited" from the old version of the site that still exists on the `main` branch. Here it's simply deleted, as has also been done in the past for www-sanity-io.

## Testing this PR
1. Open [the front page](https://structured-content-2022-web-git-disable-smooth-scroll.sanity.build/) in Chromium
2. Scroll down until the header nav shows up, then click "About"
3. Verify that the page scrolls instantly back up to the top when Next replaces the page contents via its custom JavaScript+XHR "page load", and doesn't scroll smoothly down a little bit and then up, as was described in Shortcut

It's also possible to test in Firefox and compare to the behavior on staging—this is probably timing-dependent, but on my machine/internet connection, if I load the front page on staging, scroll all the way down to the bottom of the page and then click "Venues", it usually fails to scroll back to the top (just stays down by the footer as the page contents are replaced). With this branch, it scrolls back to the top.