### PR TITLE
Hero summary, CTA

### DIFF
--- a/web/components/Hero/Hero.module.css
+++ b/web/components/Hero/Hero.module.css
@@ -4,6 +4,13 @@
   padding: 40px 0 80px;
 }
 
+.summary {
+  font: var(--font-body-small-medium);
+  letter-spacing: var(--letter-spacing-body-small);
+  margin: 32px auto 0 auto;
+  max-width: var(--max-body-text-width);
+}
+
 .cta {
   margin-top: 32px;
 }
@@ -11,6 +18,12 @@
 @media (--medium-up) {
   .container {
     padding: 96px 0;
+  }
+
+  .summary {
+    font: var(--font-body-base-medium);
+    letter-spacing: var(--letter-spacing-body-base);
+    margin-top: 40px;
   }
 
   .cta {
@@ -32,5 +45,10 @@
   .heading,
   .cta {
     grid-column: 3 / span 8;
+  }
+
+  .summary {
+    grid-column: 4 / span 6;
+    max-width: none;
   }
 }

--- a/web/components/Hero/Hero.tsx
+++ b/web/components/Hero/Hero.tsx
@@ -3,18 +3,20 @@ import GridWrapper from '../GridWrapper';
 import styles from './Hero.module.css';
 
 interface HeroProps {
-  heading: string;
+  heading?: string;
+  summary?: string;
   cta?: {
     url: string;
     text: string;
   };
 }
 
-export const Hero = ({ heading, cta }: HeroProps) => (
+export const Hero = ({ heading, summary, cta }: HeroProps) => (
   <div className={styles.container}>
     <GridWrapper>
       <div className={styles.headingContainer}>
         <h1 className={styles.heading}>{heading}</h1>
+        {summary && <p className={styles.summary}>{summary}</p>}
         {cta && (
           <div className={styles.cta}>
             <ButtonLink text={cta.text} url={cta.url} />

--- a/web/components/Hero/Hero.tsx
+++ b/web/components/Hero/Hero.tsx
@@ -1,25 +1,17 @@
-import ButtonLink from '../ButtonLink';
+import { Hero as HeroProps } from '../../types/Hero';
 import GridWrapper from '../GridWrapper';
+import SimpleCallToAction from '../TextBlock/SimpleCallToAction';
 import styles from './Hero.module.css';
 
-interface HeroProps {
-  heading?: string;
-  summary?: string;
-  cta?: {
-    url: string;
-    text: string;
-  };
-}
-
-export const Hero = ({ heading, summary, cta }: HeroProps) => (
+export const Hero = ({ heading, summary, callToAction }: HeroProps) => (
   <div className={styles.container}>
     <GridWrapper>
       <div className={styles.headingContainer}>
         <h1 className={styles.heading}>{heading}</h1>
         {summary && <p className={styles.summary}>{summary}</p>}
-        {cta && (
+        {callToAction && (
           <div className={styles.cta}>
-            <ButtonLink text={cta.text} url={cta.url} />
+            <SimpleCallToAction value={callToAction} />
           </div>
         )}
       </div>

--- a/web/components/Hero/Hero.tsx
+++ b/web/components/Hero/Hero.tsx
@@ -1,6 +1,6 @@
 import { Hero as HeroProps } from '../../types/Hero';
 import GridWrapper from '../GridWrapper';
-import SimpleCallToAction from '../TextBlock/SimpleCallToAction';
+import SimpleCallToAction from '../SimpleCallToAction';
 import styles from './Hero.module.css';
 
 export const Hero = ({ heading, summary, callToAction }: HeroProps) => (
@@ -11,7 +11,7 @@ export const Hero = ({ heading, summary, callToAction }: HeroProps) => (
         {summary && <p className={styles.summary}>{summary}</p>}
         {callToAction && (
           <div className={styles.cta}>
-            <SimpleCallToAction value={callToAction} />
+            <SimpleCallToAction {...callToAction} />
           </div>
         )}
       </div>

--- a/web/components/SimpleCallToAction/SimpleCallToAction.tsx
+++ b/web/components/SimpleCallToAction/SimpleCallToAction.tsx
@@ -1,0 +1,13 @@
+import { SimpleCallToAction as SimpleCallToActionProps } from '../../../types/SimpleCallToAction';
+import ButtonLink from '../ButtonLink';
+
+export const SimpleCallToAction = ({
+  text,
+  url,
+  reference,
+}: SimpleCallToActionProps) =>
+  text && reference?.slug?.current ? (
+    <ButtonLink text={text} url={`/${reference?.slug?.current}`} />
+  ) : text && url ? (
+    <ButtonLink text={text} url={url} />
+  ) : null;

--- a/web/components/SimpleCallToAction/SimpleCallToAction.tsx
+++ b/web/components/SimpleCallToAction/SimpleCallToAction.tsx
@@ -1,4 +1,4 @@
-import { SimpleCallToAction as SimpleCallToActionProps } from '../../../types/SimpleCallToAction';
+import { SimpleCallToAction as SimpleCallToActionProps } from '../../types/SimpleCallToAction';
 import ButtonLink from '../ButtonLink';
 
 export const SimpleCallToAction = ({

--- a/web/components/SimpleCallToAction/index.ts
+++ b/web/components/SimpleCallToAction/index.ts
@@ -1,0 +1,1 @@
+export { SimpleCallToAction as default } from './SimpleCallToAction';

--- a/web/components/TextBlock/SimpleCallToAction/SimpleCallToAction.tsx
+++ b/web/components/TextBlock/SimpleCallToAction/SimpleCallToAction.tsx
@@ -1,14 +1,6 @@
 import { PortableTextComponentProps } from '@portabletext/react';
+import { SimpleCallToAction as SimpleCallToActionProps } from '../../../types/SimpleCallToAction';
 import ButtonLink from '../../ButtonLink';
-
-type SimpleCallToActionProps = {
-  text: string;
-  reference?: {
-    slug?: {
-      current: string;
-    };
-  };
-};
 
 export const SimpleCallToAction = ({
   value: { text, reference },

--- a/web/components/TextBlock/SimpleCallToAction/SimpleCallToAction.tsx
+++ b/web/components/TextBlock/SimpleCallToAction/SimpleCallToAction.tsx
@@ -3,8 +3,10 @@ import { SimpleCallToAction as SimpleCallToActionProps } from '../../../types/Si
 import ButtonLink from '../../ButtonLink';
 
 export const SimpleCallToAction = ({
-  value: { text, reference },
+  value: { text, url, reference },
 }: PortableTextComponentProps<SimpleCallToActionProps>) =>
   text && reference?.slug?.current ? (
     <ButtonLink text={text} url={`/${reference?.slug?.current}`} />
+  ) : text && url ? (
+    <ButtonLink text={text} url={url} />
   ) : null;

--- a/web/components/TextBlock/SimpleCallToAction/SimpleCallToAction.tsx
+++ b/web/components/TextBlock/SimpleCallToAction/SimpleCallToAction.tsx
@@ -5,6 +5,6 @@ import ButtonLink from '../../ButtonLink';
 export const SimpleCallToAction = ({
   value: { text, reference },
 }: PortableTextComponentProps<SimpleCallToActionProps>) =>
-  reference?.slug?.current ? (
+  text && reference?.slug?.current ? (
     <ButtonLink text={text} url={`/${reference?.slug?.current}`} />
   ) : null;

--- a/web/components/TextBlock/SimpleCallToAction/SimpleCallToAction.tsx
+++ b/web/components/TextBlock/SimpleCallToAction/SimpleCallToAction.tsx
@@ -1,12 +1,7 @@
 import { PortableTextComponentProps } from '@portabletext/react';
 import { SimpleCallToAction as SimpleCallToActionProps } from '../../../types/SimpleCallToAction';
-import ButtonLink from '../../ButtonLink';
+import Cta from '../../SimpleCallToAction';
 
 export const SimpleCallToAction = ({
-  value: { text, url, reference },
-}: PortableTextComponentProps<SimpleCallToActionProps>) =>
-  text && reference?.slug?.current ? (
-    <ButtonLink text={text} url={`/${reference?.slug?.current}`} />
-  ) : text && url ? (
-    <ButtonLink text={text} url={url} />
-  ) : null;
+  value,
+}: PortableTextComponentProps<SimpleCallToActionProps>) => <Cta {...value} />;

--- a/web/pages/[[...slug]].tsx
+++ b/web/pages/[[...slug]].tsx
@@ -169,11 +169,7 @@ const Route = ({
             <NavBlock ticketsUrl={ticketsUrl} />
           </GridWrapper>
         ) : (
-          <Hero
-            heading={hero?.heading || name}
-            summary={hero?.summary}
-            cta={hero?.callToAction}
-          />
+          <Hero {...hero} />
         )}
         <TextBlock value={sections} />
       </main>

--- a/web/pages/[[...slug]].tsx
+++ b/web/pages/[[...slug]].tsx
@@ -169,7 +169,11 @@ const Route = ({
             <NavBlock ticketsUrl={ticketsUrl} />
           </GridWrapper>
         ) : (
-          <Hero heading={hero?.heading || name} cta={hero?.callToAction} />
+          <Hero
+            heading={hero?.heading || name}
+            summary={hero?.summary}
+            cta={hero?.callToAction}
+          />
         )}
         <TextBlock value={sections} />
       </main>

--- a/web/pages/[[...slug]].tsx
+++ b/web/pages/[[...slug]].tsx
@@ -11,6 +11,7 @@ import Nav from '../components/Nav';
 import client from '../lib/sanity.server';
 import { Slug } from '../types/Slug';
 import { Section } from '../types/Section';
+import { Hero as HeroProps } from '../types/Hero';
 import { mainEventId } from '../util/entityPaths';
 import styles from './app.module.css';
 
@@ -20,6 +21,7 @@ const QUERY = groq`
       ...,
       page-> {
         name,
+        hero,
         sections[] {
           _type == 'reference' => @-> {
             sections[] {
@@ -84,7 +86,8 @@ interface RouteProps {
   data: {
     route: {
       page: {
-        name: string;
+        name?: string;
+        hero?: HeroProps;
         sections: Section[];
       };
     };
@@ -109,7 +112,7 @@ interface RouteProps {
 const Route = ({
   data: {
     route: {
-      page: { name, sections },
+      page: { name, hero, sections },
     },
     home: { name: homeName, startDate, endDate, description, ticketsUrl },
     footer,
@@ -166,7 +169,7 @@ const Route = ({
             <NavBlock ticketsUrl={ticketsUrl} />
           </GridWrapper>
         ) : (
-          <Hero heading={name} />
+          <Hero heading={hero?.heading || name} cta={hero?.callToAction} />
         )}
         <TextBlock value={sections} />
       </main>

--- a/web/types/Hero.ts
+++ b/web/types/Hero.ts
@@ -1,0 +1,7 @@
+import { SimpleCallToAction } from './SimpleCallToAction';
+
+export type Hero = {
+  heading?: string;
+  summary?: string;
+  callToAction?: SimpleCallToAction;
+};

--- a/web/types/SimpleCallToAction.ts
+++ b/web/types/SimpleCallToAction.ts
@@ -1,8 +1,8 @@
+import { Slug } from './Slug';
+
 export type SimpleCallToAction = {
   text: string;
   reference?: {
-    slug?: {
-      current: string;
-    };
+    slug?: Slug;
   };
 };

--- a/web/types/SimpleCallToAction.ts
+++ b/web/types/SimpleCallToAction.ts
@@ -1,0 +1,8 @@
+export type SimpleCallToAction = {
+  text: string;
+  reference?: {
+    slug?: {
+      current: string;
+    };
+  };
+};

--- a/web/types/SimpleCallToAction.ts
+++ b/web/types/SimpleCallToAction.ts
@@ -1,7 +1,7 @@
 import { Slug } from './Slug';
 
 export type SimpleCallToAction = {
-  text: string;
+  text?: string;
   reference?: {
     slug?: Slug;
   };

--- a/web/types/SimpleCallToAction.ts
+++ b/web/types/SimpleCallToAction.ts
@@ -2,6 +2,7 @@ import { Slug } from './Slug';
 
 export type SimpleCallToAction = {
   text?: string;
+  url?: string;
   reference?: {
     slug?: Slug;
   };


### PR DESCRIPTION
# Hero summary, CTA

## Intent

Add support for showing a summary paragraph and/or a "call to action" in a page's "hero" (page-specific header).

## Description

Here I've tried to reuse the TypeScript definition for the Sanity fields in the component itself. Upside is that it's less duplication, but downsides might be that you have to go looking in some other file for the type, plus increased coupling between components and Sanity fields.

Also not sure about how to handle the `PortableTextComponentProps` issue (see [Vercel build of a992e90](https://vercel.com/sanity-io/structured-content-2022-web/7TQzhTmZS7wEFPTwtKMTSVewupNa) which failed). Right now I've split it into two: one component that exists to be used as a "Portable Text component", and one "plain" component which can be used elsewhere (and the former just forwards to the latter). Could be a bit confusing…

I left the `name` field since I can still see it in the [staging studio](https://stagingadmin.structuredcontent.live/) (which doesn't seem to be updated to the latest staging commit?) and some pages still seem to have it, such as /venues. Could remove support for it completely, though.

## Testing this PR
1. Open [/registration-info](https://structured-content-2022-web-63p68j6ki.sanity.build/registration-info) (which at the time of writing has contents for the summary and CTA)
2. Verify that the "hero" section at the top of the page looks OK, with header, intro and "button" leading to www.hopin.com