### PR TITLE
Editorial articles

### DIFF
--- a/web/components/Footer/Footer.module.css
+++ b/web/components/Footer/Footer.module.css
@@ -22,6 +22,7 @@
 
 .social {
   margin: 38px 0;
+  padding: 0;
   text-align: center;
 }
 
@@ -49,6 +50,7 @@
 .links {
   list-style: none;
   margin: 20px -12px 0;
+  padding: 0;
   text-align: center;
 }
 

--- a/web/components/Nav/Nav.module.css
+++ b/web/components/Nav/Nav.module.css
@@ -19,6 +19,7 @@
 
 .items {
   margin: 0;
+  padding: 0;
   list-style: none;
   display: flex;
   flex-wrap: wrap;

--- a/web/components/NavBlock/NavBlock.module.css
+++ b/web/components/NavBlock/NavBlock.module.css
@@ -7,6 +7,7 @@
   flex-wrap: wrap;
   list-style: none;
   margin: 0 -8px 0 0;
+  padding: 0;
   align-items: stretch;
 }
 

--- a/web/components/Sponsors/Sponsors.module.css
+++ b/web/components/Sponsors/Sponsors.module.css
@@ -12,6 +12,7 @@
   flex-wrap: wrap;
   justify-content: center;
   margin: 24px -4px 0;
+  padding: 0;
 }
 
 .sponsor {

--- a/web/components/TextBlock/QuestionAndAnswerCollection/QuestionAndAnswerCollection.module.css
+++ b/web/components/TextBlock/QuestionAndAnswerCollection/QuestionAndAnswerCollection.module.css
@@ -11,6 +11,8 @@
 
 .answer {
   margin-top: 22px;
+  font: var(--font-body-small);
+  letter-spacing: var(--letter-spacing-body-small);
 }
 
 @media (--medium-up) {
@@ -24,6 +26,12 @@
     max-width: var(--max-body-text-width);
     margin-left: auto;
     margin-right: auto;
+  }
+
+  .answer {
+    margin-top: 25px;
+    font: var(--font-body-base);
+    letter-spacing: var(--letter-spacing-body-base);
   }
 }
 

--- a/web/components/TextBlock/RichText/RichText.module.css
+++ b/web/components/TextBlock/RichText/RichText.module.css
@@ -25,6 +25,10 @@
     max-width: var(--max-body-text-width);
     margin: 0 auto;
   }
+
+  .subHeading {
+    font: var(--font-body-large-medium);
+  }
 }
 
 @media (--large-up) {

--- a/web/components/TextBlock/RichText/RichText.tsx
+++ b/web/components/TextBlock/RichText/RichText.tsx
@@ -18,12 +18,14 @@ export const RichText = ({ value, background }: RichTextProps) => (
   <GridWrapper>
     <div className={clsx(styles.container, background && styles.background)}>
       <div className={styles.content}>
-        <hgroup>
-          {value.heading && <Heading type="h2">{value.heading}</Heading>}
-          {value.subheading && (
-            <h3 className={styles.subHeading}>{value.subheading}</h3>
-          )}
-        </hgroup>
+        {value.heading && (
+          <hgroup>
+            {value.heading && <Heading type="h2">{value.heading}</Heading>}
+            {value.subheading && (
+              <h3 className={styles.subHeading}>{value.subheading}</h3>
+            )}
+          </hgroup>
+        )}
         <TextBlock value={value.content} />
       </div>
     </div>

--- a/web/components/VenueNames/VenueNames.module.css
+++ b/web/components/VenueNames/VenueNames.module.css
@@ -1,6 +1,7 @@
 .venues {
   text-align: center;
   margin: 80px 0 48px;
+  padding: 0;
 }
 
 .venue {

--- a/web/pages/article/[slug].tsx
+++ b/web/pages/article/[slug].tsx
@@ -46,7 +46,7 @@ interface ArticleRouteProps {
 
 const ArticleRoute = ({
   data: {
-    article: { heading, content },
+    article: { heading, summary, content },
     home: { ticketsUrl },
     footer,
   },
@@ -61,7 +61,7 @@ const ArticleRoute = ({
       />
     </header>
     <main>
-      <Hero heading={heading} />
+      <Hero heading={heading} summary={summary} />
       <GridWrapper>
         <TextBlock value={content} />
       </GridWrapper>

--- a/web/pages/article/[slug].tsx
+++ b/web/pages/article/[slug].tsx
@@ -1,0 +1,89 @@
+import clsx from 'clsx';
+import { groq } from 'next-sanity';
+import { useEffect, useState } from 'react';
+import Hero from '../../components/Hero';
+import TextBlock from '../../components/TextBlock';
+import Footer from '../../components/Footer';
+import Nav from '../../components/Nav';
+import client from '../../lib/sanity.server';
+import { Slug } from '../../types/Slug';
+import styles from '../app.module.css';
+import { mainEventId } from '../../util/entityPaths';
+import GridWrapper from '../../components/GridWrapper';
+import { Article } from "../../types/Article";
+
+const QUERY = groq`
+  {
+    "article": *[_type == "article" && slug.current == $slug][0] {
+      ...,
+    },
+    "home": *[_id == "${mainEventId}"][0] {
+      "ticketsUrl": microcopy[key == "mainCta"][0].action,
+    },
+    "footer": *[_id == "secondary-nav"][0] {
+      "links": tree[].value.reference-> {
+        "name": seo.title,
+        slug,
+        _id,
+      }
+    },
+  }`;
+
+interface ArticleRouteProps {
+  data: {
+    article: Article;
+    home: {
+      ticketsUrl: string;
+    };
+    footer: {
+      links: {
+        name: string;
+        slug: Slug;
+        _id: string;
+      }[];
+    };
+  };
+  slug: string;
+}
+
+const ArticleRoute = ({
+  data: {
+    article: { heading, content },
+    home: { ticketsUrl },
+    footer,
+  },
+  slug,
+}: ArticleRouteProps) => (
+  <>
+    <header className={styles.header}>
+      <Nav
+        onFrontPage={false}
+        currentPath={`/article/${slug}`}
+        ticketsUrl={ticketsUrl}
+      />
+    </header>
+    <main>
+      <Hero heading={heading} />
+      <GridWrapper>
+        <TextBlock value={content} />
+      </GridWrapper>
+    </main>
+    <Footer links={footer.links} />
+  </>
+);
+
+export async function getServerSideProps({ params }) {
+  const slug = params?.slug;
+  if (!slug) {
+    return { notFound: true };
+  }
+
+  const data = await client.fetch(QUERY, { slug });
+  if (!data?.article?._id) {
+    return { notFound: true };
+  }
+
+  return { props: { data, slug } };
+}
+
+export default ArticleRoute;

--- a/web/pages/article/[slug].tsx
+++ b/web/pages/article/[slug].tsx
@@ -10,7 +10,7 @@ import { Slug } from '../../types/Slug';
 import styles from '../app.module.css';
 import { mainEventId } from '../../util/entityPaths';
 import GridWrapper from '../../components/GridWrapper';
-import { Article } from "../../types/Article";
+import { Article } from '../../types/Article';
 
 const QUERY = groq`
   {

--- a/web/pages/article/[slug].tsx
+++ b/web/pages/article/[slug].tsx
@@ -2,14 +2,13 @@ import clsx from 'clsx';
 import { groq } from 'next-sanity';
 import { useEffect, useState } from 'react';
 import Hero from '../../components/Hero';
-import TextBlock from '../../components/TextBlock';
+import RichText from '../../components/TextBlock/RichText';
 import Footer from '../../components/Footer';
 import Nav from '../../components/Nav';
 import client from '../../lib/sanity.server';
 import { Slug } from '../../types/Slug';
 import styles from '../app.module.css';
 import { mainEventId } from '../../util/entityPaths';
-import GridWrapper from '../../components/GridWrapper';
 import { Article } from '../../types/Article';
 
 const QUERY = groq`
@@ -62,9 +61,7 @@ const ArticleRoute = ({
     </header>
     <main>
       <Hero heading={heading} summary={summary} />
-      <GridWrapper>
-        <TextBlock value={content} />
-      </GridWrapper>
+      <RichText value={{ content }} />
     </main>
     <Footer links={footer.links} />
   </>

--- a/web/pages/article/[slug].tsx
+++ b/web/pages/article/[slug].tsx
@@ -2,13 +2,15 @@ import clsx from 'clsx';
 import { groq } from 'next-sanity';
 import { useEffect, useState } from 'react';
 import Hero from '../../components/Hero';
-import RichText from '../../components/TextBlock/RichText';
+import TextBlock from '../../components/TextBlock';
 import Footer from '../../components/Footer';
 import Nav from '../../components/Nav';
 import client from '../../lib/sanity.server';
 import { Slug } from '../../types/Slug';
 import styles from '../app.module.css';
+import articleStyles from './article.module.css';
 import { mainEventId } from '../../util/entityPaths';
+import GridWrapper from '../../components/GridWrapper';
 import { Article } from '../../types/Article';
 
 const QUERY = groq`
@@ -61,7 +63,17 @@ const ArticleRoute = ({
     </header>
     <main>
       <Hero heading={heading} summary={summary} />
-      <RichText value={{ content }} />
+      {/* This is a workaround for TextBlock and the types it handles currently
+       * being tied to PortableText. Ideally we would just reuse the RichText
+       * component here instead of copy/pasting the wrappers/CSS.
+       */}
+      <GridWrapper>
+        <div className={articleStyles.container}>
+          <div className={articleStyles.content}>
+            <TextBlock value={content} />
+          </div>
+        </div>
+      </GridWrapper>
     </main>
     <Footer links={footer.links} />
   </>

--- a/web/pages/article/[slug].tsx
+++ b/web/pages/article/[slug].tsx
@@ -14,9 +14,7 @@ import { Article } from "../../types/Article";
 
 const QUERY = groq`
   {
-    "article": *[_type == "article" && slug.current == $slug][0] {
-      ...,
-    },
+    "article": *[_type == "article" && slug.current == $slug][0],
     "home": *[_id == "${mainEventId}"][0] {
       "ticketsUrl": microcopy[key == "mainCta"][0].action,
     },

--- a/web/pages/article/article.module.css
+++ b/web/pages/article/article.module.css
@@ -1,0 +1,20 @@
+.container {
+  margin: 80px 0;
+}
+
+@media (--medium-up) {
+  .container {
+    margin: 96px 0;
+  }
+
+  .content {
+    max-width: var(--max-body-text-width);
+    margin: 0 auto;
+  }
+}
+
+@media (--large-up) {
+  .container {
+    margin: 128px 0;
+  }
+}

--- a/web/styles/globals.css
+++ b/web/styles/globals.css
@@ -65,6 +65,11 @@ input {
 }
 
 @media (--medium-up) {
+  body {
+    font: var(--font-body-large);
+    letter-spacing: var(--letter-spacing-body-large);
+  }
+
   body.main-menu-open {
     overflow: auto;
   }

--- a/web/styles/globals.css
+++ b/web/styles/globals.css
@@ -47,6 +47,11 @@ h2 {
   margin: 80px 0 18px;
 }
 
+h3 {
+  font: var(--font-body-base-bold);
+  margin: 1em 0;
+}
+
 p,
 ul,
 ol {
@@ -81,6 +86,10 @@ input {
   h2 {
     font: var(--font-display-base);
     margin: 96px 0 30px;
+  }
+
+  h3 {
+    font: var(--font-body-large-bold);
   }
 }
 

--- a/web/styles/globals.css
+++ b/web/styles/globals.css
@@ -56,7 +56,11 @@ p,
 ul,
 ol {
   margin: 0 0 1em;
-  padding: 0;
+}
+
+ul {
+  padding-left: 1.5em;
+  list-style-type: disc;
 }
 
 a {

--- a/web/styles/globals.css
+++ b/web/styles/globals.css
@@ -42,6 +42,11 @@ h1 {
   margin: 0;
 }
 
+h2 {
+  font: var(--font-display-xs);
+  margin: 80px 0 18px;
+}
+
 p,
 ul,
 ol {
@@ -67,10 +72,19 @@ input {
   h1 {
     font: var(--font-display-xl);
   }
+
+  h2 {
+    font: var(--font-display-base);
+    margin: 96px 0 30px;
+  }
 }
 
 @media (--large-up) {
   h1 {
     font: var(--font-display-2xl);
+  }
+
+  h2 {
+    margin-top: 128px;
   }
 }

--- a/web/styles/variables.css
+++ b/web/styles/variables.css
@@ -12,6 +12,7 @@
   --color-ui-gray-100: #f4f3ef;
   --font-body-base: 400 18px/25px 'Inter', sans-serif;
   --font-body-base-medium: 500 18px/25px 'Inter', sans-serif;
+  --font-body-base-bold: 700 18px/25px 'Inter', sans-serif;
   --font-body-large: 400 20px/30px 'Inter', sans-serif;
   --font-body-large-bold: 700 20px/30px 'Inter', sans-serif;
   --font-body-large-medium: 500 20px/30px 'Inter', sans-serif;

--- a/web/styles/variables.css
+++ b/web/styles/variables.css
@@ -12,8 +12,10 @@
   --color-ui-gray-100: #f4f3ef;
   --font-body-base: 400 18px/25px 'Inter', sans-serif;
   --font-body-base-medium: 500 18px/25px 'Inter', sans-serif;
+  --font-body-large: 400 20px/30px 'Inter', sans-serif;
   --font-body-large-bold: 700 20px/30px 'Inter', sans-serif;
   --font-body-large-medium: 500 20px/30px 'Inter', sans-serif;
+  --font-body-small: 400 16px/22px 'Inter', sans-serif;
   --font-body-small-bold: 700 16px/22px 'Inter', sans-serif;
   --font-body-small-medium: 500 16px/22px 'Inter', sans-serif;
   --font-body-xl-medium: 500 24px/33px 'Inter', sans-serif;

--- a/web/types/Article.ts
+++ b/web/types/Article.ts
@@ -1,10 +1,11 @@
 import { Slug } from "./Slug";
+import { Section } from "./Section";
 
 export type Article = {
   _id: string;
   _rev: string;
   _type: 'article';
-  content: any[];
+  content: Section[];
   heading: string;
   publishedAt: string;
   slug: Slug;

--- a/web/types/Article.ts
+++ b/web/types/Article.ts
@@ -1,5 +1,5 @@
-import { Slug } from "./Slug";
-import { Section } from "./Section";
+import { Slug } from './Slug';
+import { Section } from './Section';
 
 export type Article = {
   _id: string;

--- a/web/types/Article.ts
+++ b/web/types/Article.ts
@@ -1,0 +1,13 @@
+import { Slug } from "./Slug";
+
+export type Article = {
+  _id: string;
+  _rev: string;
+  _type: 'article';
+  content: any[];
+  heading: string;
+  publishedAt: string;
+  slug: Slug;
+  summary: string;
+  _updatedAt: string;
+};


### PR DESCRIPTION
# Editorial articles

## Intent

Render (to-be-styled) [Editorial Articles](http://localhost:3333/desk/article;febd810c-706d-46e2-a391-3e910fc4b06c), e.g. Code of Conduct on  the `/articles/:slug` path.

## RFC

I opted for a separate route rather than stuffing more content into _[[...slug]].tsx_, but the latter might also be an option. Thoughts?

## Testing this PR

Go to [/article/code-of-conduct](https://structured-content-2022-web-35sdjq4pa.sanity.build/article/code-of-conduct) and verify that the content of the respective [Editorial Article](http://localhost:3333/desk/article;febd810c-706d-46e2-a391-3e910fc4b06c) renders. 