### PR TITLE
Fix internal Hero CTA

### DIFF
--- a/web/pages/[[...slug]].tsx
+++ b/web/pages/[[...slug]].tsx
@@ -21,7 +21,13 @@ const QUERY = groq`
       ...,
       page-> {
         name,
-        hero,
+        hero {
+          ...,
+          callToAction {
+            ...,
+            reference->{slug},
+          },
+        },
         sections[] {
           _type == 'reference' => @-> {
             sections[] {


### PR DESCRIPTION
# Fix internal Hero CTA

## Intent

Fix rendering of "Call to action" in a landing page's "Hero" component, in the case where that CTA is referencing a "Route" document rather than specifying a URL

## Description

Was missing some dereferencing in the query here.

Also related to this CTA is the fact that it could be pointing to an `article` instead of a `page`. It seems it's currently unclear how slugs on these articles should work (see Slack threads e.g. on our [shared channel with Behalf](https://wja.slack.com/archives/C02E2ERKR7E/p1646129047370819)). Depending on how that turns out, the SimpleCallToAction component may need some sort of helper function to handle converting the slug into a URL, along the lines of web/util/entityPaths.ts.

Because of this uncertainty, the latter problem is not handled in this PR.

## Testing this PR
1. Open the [Venues](https://structured-content-2022-web-qp8p6f38f.sanity.build/venues) page
2. Verify that there is a "Get registration info" button (link) right below the page summary (topmost yellow section)