### PR TITLE
Meta tags for SEO

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -14,12 +14,15 @@
     "date-fns": "^2.28.0",
     "next": "12.0.8",
     "next-sanity": "^0.4.0",
+    "next-seo": "^5.1.0",
+    "proper-url-join": "^2.1.1",
     "react": "17.0.2",
     "react-cookie-consent": "^7.2.1",
     "react-dom": "17.0.2",
     "react-gtm-module": "^2.0.11"
   },
   "devDependencies": {
+    "@types/proper-url-join": "^2.1.1",
     "@types/react": "^17.0.38",
     "autoprefixer": "^10.4.2",
     "eslint": "8.6.0",

--- a/web/pages/[[...slug]].tsx
+++ b/web/pages/[[...slug]].tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx';
 import { groq } from 'next-sanity';
-import { NextSeo } from "next-seo";
-import urlJoin from "proper-url-join";
+import { NextSeo } from 'next-seo';
+import urlJoin from 'proper-url-join';
 import { useEffect, useState } from 'react';
 import Hero from '../components/Hero';
 import TextBlock from '../components/TextBlock';
@@ -93,14 +93,14 @@ interface RouteProps {
         sections: Section[];
       };
       seo: {
-        _type: 'seo',
+        _type: 'seo';
         title: string;
         description: string;
         image?: {
           asset: {
             url: string;
-          }
-        },
+          };
+        };
         noIndex?: boolean;
       };
     };
@@ -169,7 +169,7 @@ const Route = ({
         description={seoDescription}
         canonical={urlJoin('https://structuredcontent.live', currentPath)}
         noindex={noIndex}
-        openGraph={image ? { images: [{ url: image?.asset?.url }] }  : undefined}
+        openGraph={image ? { images: [{ url: image?.asset?.url }] } : undefined}
       />
       <header className={headerClasses}>
         <Nav

--- a/web/pages/[[...slug]].tsx
+++ b/web/pages/[[...slug]].tsx
@@ -16,6 +16,7 @@ import { Section } from '../types/Section';
 import { Hero as HeroProps } from '../types/Hero';
 import { mainEventId } from '../util/entityPaths';
 import styles from './app.module.css';
+import { imageUrlFor } from '../lib/sanity';
 
 const QUERY = groq`
   {
@@ -188,7 +189,20 @@ const Route = ({
         description={seoDescription}
         canonical={urlJoin('https://structuredcontent.live', currentPath)}
         noindex={noIndex}
-        openGraph={image ? { images: [{ url: image?.asset?.url }] } : undefined}
+        openGraph={
+          image
+            ? {
+                images: [
+                  {
+                    url: imageUrlFor(image)
+                      .ignoreImageParams()
+                      .size(1260, 630)
+                      .url(),
+                  },
+                ],
+              }
+            : undefined
+        }
       />
       <header className={headerClasses}>
         <Nav

--- a/web/pages/[[...slug]].tsx
+++ b/web/pages/[[...slug]].tsx
@@ -1,5 +1,7 @@
 import clsx from 'clsx';
 import { groq } from 'next-sanity';
+import { NextSeo } from "next-seo";
+import urlJoin from "proper-url-join";
 import { useEffect, useState } from 'react';
 import Hero from '../components/Hero';
 import TextBlock from '../components/TextBlock';
@@ -90,6 +92,17 @@ interface RouteProps {
         hero?: HeroProps;
         sections: Section[];
       };
+      seo: {
+        _type: 'seo',
+        title: string;
+        description: string;
+        image?: {
+          asset: {
+            url: string;
+          }
+        },
+        noIndex?: boolean;
+      };
     };
     home: {
       name: string;
@@ -113,6 +126,7 @@ const Route = ({
   data: {
     route: {
       page: { name, hero, sections },
+      seo: { title, description: seoDescription, image, noIndex },
     },
     home: { name: homeName, startDate, endDate, description, ticketsUrl },
     footer,
@@ -150,6 +164,13 @@ const Route = ({
 
   return (
     <>
+      <NextSeo
+        title={title}
+        description={seoDescription}
+        canonical={urlJoin('https://structuredcontent.live', currentPath)}
+        noindex={noIndex}
+        openGraph={image ? { images: [{ url: image?.asset?.url }] }  : undefined}
+      />
       <header className={headerClasses}>
         <Nav
           onFrontPage={isFrontPage}

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -338,6 +338,13 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.4.tgz#fcf7205c25dff795ee79af1e30da2c9790808f11"
   integrity sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==
 
+"@types/proper-url-join@^2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@types/proper-url-join/-/proper-url-join-2.1.1.tgz#e78f6cc7306f1140c5cac2fddf253070ecbdda85"
+  integrity sha512-OfcRK+o4tTHLwhB07ENYTeKZfzRn4ci4vOalLmdDraCYAcJxJJzvpxo0hLxExRM/QIuGzcF09pNeYol6hiyCXQ==
+  dependencies:
+    query-string "^6.3.0"
+
 "@types/react@^17.0.0":
   version "17.0.39"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.39.tgz#d0f4cde092502a6db00a1cded6e6bf2abb7633ce"
@@ -690,6 +697,11 @@ debug@^4.1.1, debug@^4.3.1, debug@^4.3.2:
   integrity sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==
   dependencies:
     ms "2.1.2"
+
+decode-uri-component@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
+  integrity sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
 
 decompress-response@^3.3.0:
   version "3.3.0"
@@ -1076,6 +1088,11 @@ fill-range@^7.0.1:
   integrity sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
   dependencies:
     to-regex-range "^5.0.1"
+
+filter-obj@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/filter-obj/-/filter-obj-1.1.0.tgz#9b311112bc6c6127a16e016c6c5d7f19e0805c5b"
+  integrity sha1-mzERErxsYSehbgFsbF1/GeCAXFs=
 
 find-up@^2.1.0:
   version "2.1.0"
@@ -1703,6 +1720,11 @@ next-sanity@^0.4.0:
     groq "^2.14.0"
     use-deep-compare-effect "^1.6.1"
 
+next-seo@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/next-seo/-/next-seo-5.1.0.tgz#aa9fd6249a11bf93e6da06fa2a6bc89268936edf"
+  integrity sha512-ampuQfNTOi1x+xtRIb6CZGunIo6rQXtMo2Tyu861d5GjJFIwfOXsA4lzCa4+e2rLkyXDyVpavNNUZWa3US9ELw==
+
 next@12.0.8:
   version "12.0.8"
   resolved "https://registry.yarnpkg.com/next/-/next-12.0.8.tgz#29138f7cdd045e4bbba466af45bf430e769634b4"
@@ -1976,10 +1998,27 @@ prop-types@^15.6.2, prop-types@^15.7.2:
     object-assign "^4.1.1"
     react-is "^16.13.1"
 
+proper-url-join@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/proper-url-join/-/proper-url-join-2.1.1.tgz#ee4146edc08f512a0ee1053a355e06950691d06f"
+  integrity sha512-40x6taKMwsDn4TrWx4YvnVxv5mO1O9KUrbK/jx8N0oDYf38ZFUK/OHNSAwTvu7Aj+cQcjBuf5aDh5R328YrrXg==
+  dependencies:
+    query-string "^6.3.0"
+
 punycode@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
+
+query-string@^6.3.0:
+  version "6.14.1"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.14.1.tgz#7ac2dca46da7f309449ba0f86b1fd28255b0c86a"
+  integrity sha512-XDxAeVmpfu1/6IjyT/gXHOl+S0vQ9owggJ30hhWKdHAsNPOcasn5o9BW0eejZqL2e4vMjhAxoW3jVHcD6mbcYw==
+  dependencies:
+    decode-uri-component "^0.2.0"
+    filter-obj "^1.1.0"
+    split-on-first "^1.0.0"
+    strict-uri-encode "^2.0.0"
 
 querystringify@^2.1.1:
   version "2.2.0"
@@ -2232,6 +2271,11 @@ speedometer@~1.0.0:
   resolved "https://registry.yarnpkg.com/speedometer/-/speedometer-1.0.0.tgz#cd671cb06752c22bca3370e2f334440be4fc62e2"
   integrity sha1-zWccsGdSwivKM3Di8zREC+T8YuI=
 
+split-on-first@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/split-on-first/-/split-on-first-1.1.0.tgz#f610afeee3b12bce1d0c30425e76398b78249a5f"
+  integrity sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==
+
 split2@^3.2.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/split2/-/split2-3.2.2.tgz#bf2cf2a37d838312c249c89206fd7a17dd12365f"
@@ -2246,6 +2290,11 @@ stream-browserify@3.0.0:
   dependencies:
     inherits "~2.0.4"
     readable-stream "^3.5.0"
+
+strict-uri-encode@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
+  integrity sha1-ucczDHBChi9rFC3CdLvMWGbONUY=
 
 string-hash@1.1.3:
   version "1.1.3"


### PR DESCRIPTION
# Meta tags for SEO

## Intent

Add basic meta tags to `<head>` using [next-seo](https://github.com/garmeeh/next-seo).

## Testing this PR

1. Go to the [frontpage](https://structured-content-2022-web-1xujtju6z.sanity.build/)
2. Verify that we render all the meta tags we can, given the `seo` fields available in Studio for the [front page Route](https://stagingadmin.structuredcontent.live/desk/route;9e8a9f97-2573-493d-aae9-3f5d8289ad58)
    * (Are there other essential tags we should render that we currently don't?)
3. Go to [/shared-sections-test](https://structured-content-2022-web-1xujtju6z.sanity.build/shared-sections-test)
4. Verify that a `noindex` meta tag is present in the document's `<head>` corresponding to the [Studio "Hide this route" setting](https://stagingadmin.structuredcontent.live/desk/route;36c8bda6-e3a3-4671-a260-cdaf3dcd2e43) being enabled for the Route