### PR TITLE
"Nav block" shapes

### DIFF
--- a/web/components/NavBlock/NavBlock.module.css
+++ b/web/components/NavBlock/NavBlock.module.css
@@ -50,6 +50,10 @@
   background: url('../../images/navblock_plus.svg') 100% 100% no-repeat;
 }
 
+.fakeItem.shapeC {
+  background: url('../../images/navblock_c.svg') 100% 100% no-repeat;
+}
+
 .fakeItem.mobile {
   display: block;
 }

--- a/web/components/NavBlock/NavBlock.module.css
+++ b/web/components/NavBlock/NavBlock.module.css
@@ -107,6 +107,10 @@
     padding: 28.5px 39px;
   }
 
+  .fakeItem {
+    border-radius: 12px;
+  }
+
   .fakeItem.tablet,
   .divider.tablet {
     display: none;

--- a/web/components/NavBlock/NavBlock.module.css
+++ b/web/components/NavBlock/NavBlock.module.css
@@ -58,6 +58,10 @@
   background: url('../../images/navblock_ovals.svg') 100% 100% no-repeat;
 }
 
+.fakeItem.shapeO {
+  background: url('../../images/navblock_o.svg') 100% 100% no-repeat;
+}
+
 .fakeItem.mobile {
   display: block;
 }

--- a/web/components/NavBlock/NavBlock.module.css
+++ b/web/components/NavBlock/NavBlock.module.css
@@ -46,6 +46,10 @@
   display: none;
 }
 
+.fakeItem.shapePlus {
+  background: url('../../images/navblock_plus.svg') 100% 100% no-repeat;
+}
+
 .fakeItem.mobile {
   display: block;
 }

--- a/web/components/NavBlock/NavBlock.module.css
+++ b/web/components/NavBlock/NavBlock.module.css
@@ -54,6 +54,10 @@
   background: url('../../images/navblock_c.svg') 100% 100% no-repeat;
 }
 
+.fakeItem.shapeOvals {
+  background: url('../../images/navblock_ovals.svg') 100% 100% no-repeat;
+}
+
 .fakeItem.mobile {
   display: block;
 }

--- a/web/components/NavBlock/NavBlock.module.css
+++ b/web/components/NavBlock/NavBlock.module.css
@@ -62,6 +62,10 @@
   background: url('../../images/navblock_o.svg') 100% 100% no-repeat;
 }
 
+.fakeItem.shapeHalfOval {
+  background: url('../../images/navblock_halfoval.svg') 100% 100% no-repeat;
+}
+
 .fakeItem.mobile {
   display: block;
 }

--- a/web/components/NavBlock/NavBlock.module.css
+++ b/web/components/NavBlock/NavBlock.module.css
@@ -47,23 +47,26 @@
 }
 
 .fakeItem.shapePlus {
-  background: url('../../images/navblock_plus.svg') 100% 100% no-repeat;
+  background: url('../../images/navblock_plus.svg') top left / 100% 100%
+    no-repeat;
 }
 
 .fakeItem.shapeC {
-  background: url('../../images/navblock_c.svg') 100% 100% no-repeat;
+  background: url('../../images/navblock_c.svg') top left / 100% 100% no-repeat;
 }
 
 .fakeItem.shapeOvals {
-  background: url('../../images/navblock_ovals.svg') 100% 100% no-repeat;
+  background: url('../../images/navblock_ovals.svg') top left / 100% 100%
+    no-repeat;
 }
 
 .fakeItem.shapeO {
-  background: url('../../images/navblock_o.svg') 100% 100% no-repeat;
+  background: url('../../images/navblock_o.svg') top left / 100% 100% no-repeat;
 }
 
 .fakeItem.shapeHalfOval {
-  background: url('../../images/navblock_halfoval.svg') 100% 100% no-repeat;
+  background: url('../../images/navblock_halfoval.svg') top left / 100% 100%
+    no-repeat;
 }
 
 .fakeItem.mobile {

--- a/web/components/NavBlock/NavBlock.tsx
+++ b/web/components/NavBlock/NavBlock.tsx
@@ -7,7 +7,7 @@ interface FakeItemProps {
   mobile?: boolean;
   tablet?: boolean;
   desktop?: boolean;
-  shape?: 'Plus';
+  shape?: 'Plus' | 'C';
 }
 
 const FakeItem = ({
@@ -48,7 +48,7 @@ export const NavBlock = ({ ticketsUrl }: NavBlockProps) => (
       <FakeItem tablet desktop />
       <FakeItem divider mobile tablet desktop />
       <FakeItem tablet desktop />
-      <FakeItem tablet desktop />
+      <FakeItem tablet desktop shape="C" />
       <FakeItem tablet desktop />
       <FakeItem mobile tablet desktop />
       <FakeItem mobile />

--- a/web/components/NavBlock/NavBlock.tsx
+++ b/web/components/NavBlock/NavBlock.tsx
@@ -7,7 +7,7 @@ interface FakeItemProps {
   mobile?: boolean;
   tablet?: boolean;
   desktop?: boolean;
-  shape?: 'Plus' | 'C' | 'Ovals';
+  shape?: 'Plus' | 'C' | 'Ovals' | 'O';
 }
 
 const FakeItem = ({
@@ -70,7 +70,7 @@ export const NavBlock = ({ ticketsUrl }: NavBlockProps) => (
       <FakeItem mobile />
       <FakeItem mobile tablet desktop />
       <FakeItem divider mobile />
-      <FakeItem desktop />
+      <FakeItem desktop shape="O" />
 
       <li className={styles.item}>
         <Link href={ticketsUrl}>

--- a/web/components/NavBlock/NavBlock.tsx
+++ b/web/components/NavBlock/NavBlock.tsx
@@ -7,15 +7,23 @@ interface FakeItemProps {
   mobile?: boolean;
   tablet?: boolean;
   desktop?: boolean;
+  shape?: 'Plus';
 }
 
-const FakeItem = ({ divider, mobile, tablet, desktop }: FakeItemProps) => (
+const FakeItem = ({
+  divider,
+  mobile,
+  tablet,
+  desktop,
+  shape,
+}: FakeItemProps) => (
   <li
     className={clsx(
       divider ? styles.divider : styles.fakeItem,
       mobile && styles.mobile,
       tablet && styles.tablet,
-      desktop && styles.desktop
+      desktop && styles.desktop,
+      shape && styles[`shape${shape}`]
     )}
     aria-hidden="true"
   />
@@ -35,7 +43,7 @@ export const NavBlock = ({ ticketsUrl }: NavBlockProps) => (
       </li>
 
       <FakeItem mobile tablet desktop />
-      <FakeItem mobile tablet desktop />
+      <FakeItem mobile tablet desktop shape="Plus" />
       <FakeItem tablet desktop />
       <FakeItem tablet desktop />
       <FakeItem divider mobile tablet desktop />

--- a/web/components/NavBlock/NavBlock.tsx
+++ b/web/components/NavBlock/NavBlock.tsx
@@ -67,7 +67,7 @@ export const NavBlock = ({ ticketsUrl }: NavBlockProps) => (
         </Link>
       </li>
 
-      <FakeItem mobile />
+      <FakeItem mobile shape="HalfOval" />
       <FakeItem mobile tablet desktop />
       <FakeItem divider mobile />
       <FakeItem desktop shape="O" />

--- a/web/components/NavBlock/NavBlock.tsx
+++ b/web/components/NavBlock/NavBlock.tsx
@@ -7,7 +7,7 @@ interface FakeItemProps {
   mobile?: boolean;
   tablet?: boolean;
   desktop?: boolean;
-  shape?: 'Plus' | 'C';
+  shape?: 'Plus' | 'C' | 'Ovals';
 }
 
 const FakeItem = ({
@@ -50,7 +50,7 @@ export const NavBlock = ({ ticketsUrl }: NavBlockProps) => (
       <FakeItem tablet desktop />
       <FakeItem tablet desktop shape="C" />
       <FakeItem tablet desktop />
-      <FakeItem mobile tablet desktop />
+      <FakeItem mobile tablet desktop shape="Ovals" />
       <FakeItem mobile />
 
       <li className={styles.item}>

--- a/web/components/NavBlock/NavBlock.tsx
+++ b/web/components/NavBlock/NavBlock.tsx
@@ -28,21 +28,22 @@ interface NavBlockProps {
 export const NavBlock = ({ ticketsUrl }: NavBlockProps) => (
   <nav className={styles.nav}>
     <ul className={styles.list}>
-      <FakeItem mobile />
-
       <li className={styles.item}>
         <Link href="/program">
           <a className={styles.link}>Program</a>
         </Link>
       </li>
 
+      <FakeItem mobile tablet desktop />
+      <FakeItem mobile tablet desktop />
       <FakeItem tablet desktop />
       <FakeItem tablet desktop />
-      <FakeItem desktop />
       <FakeItem divider mobile tablet desktop />
       <FakeItem tablet desktop />
       <FakeItem tablet desktop />
-      <FakeItem desktop />
+      <FakeItem tablet desktop />
+      <FakeItem mobile tablet desktop />
+      <FakeItem mobile />
 
       <li className={styles.item}>
         <Link href="/speakers">
@@ -50,9 +51,7 @@ export const NavBlock = ({ ticketsUrl }: NavBlockProps) => (
         </Link>
       </li>
 
-      <FakeItem mobile />
       <FakeItem divider mobile tablet desktop />
-      <FakeItem mobile />
 
       <li className={styles.item}>
         <Link href="/about">
@@ -60,8 +59,10 @@ export const NavBlock = ({ ticketsUrl }: NavBlockProps) => (
         </Link>
       </li>
 
-      <FakeItem tablet desktop />
+      <FakeItem mobile />
+      <FakeItem mobile tablet desktop />
       <FakeItem divider mobile />
+      <FakeItem desktop />
 
       <li className={styles.item}>
         <Link href={ticketsUrl}>
@@ -69,7 +70,8 @@ export const NavBlock = ({ ticketsUrl }: NavBlockProps) => (
         </Link>
       </li>
 
-      <FakeItem desktop mobile />
+      <FakeItem tablet desktop />
+      <FakeItem mobile desktop />
     </ul>
   </nav>
 );

--- a/web/components/NavBlock/NavBlock.tsx
+++ b/web/components/NavBlock/NavBlock.tsx
@@ -7,7 +7,7 @@ interface FakeItemProps {
   mobile?: boolean;
   tablet?: boolean;
   desktop?: boolean;
-  shape?: 'Plus' | 'C' | 'Ovals' | 'O';
+  shape?: 'Plus' | 'C' | 'Ovals' | 'O' | 'HalfOval';
 }
 
 const FakeItem = ({
@@ -78,7 +78,7 @@ export const NavBlock = ({ ticketsUrl }: NavBlockProps) => (
         </Link>
       </li>
 
-      <FakeItem tablet desktop />
+      <FakeItem tablet desktop shape="HalfOval" />
       <FakeItem mobile desktop />
     </ul>
   </nav>

--- a/web/images/navblock_c.svg
+++ b/web/images/navblock_c.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+  <rect x="0" y="0" width="100%" height="48%" fill="#ffba00" rx="12" />
+  <rect x="0" y="52%" width="100%" height="48%" fill="#ffba00" rx="12" />
+  <rect x="0" y="0" width="31.25%" height="100%" fill="#ffba00" rx="12" />
+</svg>

--- a/web/images/navblock_halfoval.svg
+++ b/web/images/navblock_halfoval.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+  <ellipse cx="50%" cy="0" rx="50%" ry="100%" fill="#ffba00" />
+</svg>

--- a/web/images/navblock_o.svg
+++ b/web/images/navblock_o.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+  <rect x="0" y="0" width="100%" height="100%" fill="#ffba00" rx="12" />
+  <rect x="50%" y="31.25%" width="4" height="37.5%" fill="#fff" />
+</svg>

--- a/web/images/navblock_ovals.svg
+++ b/web/images/navblock_ovals.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+  <ellipse cx="12.5%" cy="50%" rx="12.5%" ry="50%" fill="#ffba00" />
+  <ellipse cx="37.5%" cy="50%" rx="12.5%" ry="50%" fill="#ffba00" />
+  <ellipse cx="62.5%" cy="50%" rx="12.5%" ry="50%" fill="#ffba00" />
+  <ellipse cx="87.5%" cy="50%" rx="12.5%" ry="50%" fill="#ffba00" />
+</svg>

--- a/web/images/navblock_plus.svg
+++ b/web/images/navblock_plus.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+  <rect x="0" y="25%" width="100%" height="50%" fill="#ffba00" rx="12" />
+  <rect x="25%" y="0" width="50%" height="100%" fill="#ffba00" rx="12" />
+</svg>


### PR DESCRIPTION
# "Nav block" shapes

## Intent

Implement the updated design of the "Nav block", with changed number/distribution of empty boxes and with various custom shapes to make it look less like a brick wall

## Description

Shortcut: https://app.shortcut.com/sanity-io/story/15395/implement-new-design-for-nav-block

I felt that writing these shapes as SVG was the simplest way to solve it, rather than adding even more empty HTML elements and styling those in different ways.

As Sindre mentioned in the Shortcut story, SVGs exported the "normal" way will end up looking stretched in ways we don't want, with the border radiuses being stretched non-uniformly. This is basically because such SVGs will have a "natural size"/aspect ratio.

Instead, I added some hand-written SVGs that really turned out to be quite quick to make. They don't have any intrinsic/natural size, so the rounded corners aren't scaled up or down. But because I use percentages for positioning/widths etc, the SVGs still fill the area allocated to them (which is basically 100% of the background area of the given `FakeItem` `<li>`).

As discussed before we could consider inlining the SVGs as `data:` URIs if that is an improvement for performance, but I considered this out of scope for the PR since we don't have a general setup for doing this, as far as I know. (Unless we manually inline them in the CSS source. This is definitely doable just not very pretty/maintainable.)

(We also have an issue for this, in GitHub at least. I could add it to Shortcut too.)

## Testing this PR
1. Open https://structured-content-2022-web-git-nav-block-shapes.sanity.build/
2. Verify that the "nav block" of black-on-orange links (Program, Speakers etc) has various shapes in it other than plain rounded-corner rectangles, and corresponds to the "Approved" Figma sketches labelled "Homepage v2"