### PR TITLE
Remove SharedSections heading

### DIFF
--- a/web/components/TextBlock/SharedSections/SharedSections.tsx
+++ b/web/components/TextBlock/SharedSections/SharedSections.tsx
@@ -1,5 +1,4 @@
 import ConferenceUpdatesForm from '../../ConferenceUpdatesForm';
-import Heading from '../../Heading';
 import Figure from '../Figure';
 import RichText from '../RichText';
 import VenuesSection from '../VenuesSection';
@@ -10,9 +9,8 @@ import Speakers from '../Speakers';
 import Sessions from '../../Sessions';
 import Tickets from '../Tickets';
 
-export const SharedSections = ({ value: { name, sections, ...rest } }) => (
+export const SharedSections = ({ value: { sections, ...rest } }) => (
   <>
-    <Heading type="h2">{name}</Heading>
     {sections.map((section) => {
       // Matches /studio/schemas/sections/index.ts
       // plus "figure" from /studio/schemas/documents/sharedSections.ts


### PR DESCRIPTION
# Remove SharedSections heading

## Intent

Looking at the DOM of various pages including the front page, I noticed lots of empty `h2` elements appearing throughout. I'm slightly concerned that this might have an effect on accessibility, if accessibility tools don't filter such headings out (e.g. when navigating by headings). This PR intends to remove them.

## Description

As mentioned in the commit message, I couldn't see any `name` in the schema, so I don't understand how this heading would ever be non-empty. It's possible I've misunderstood something, but I looked through several pages without seeing any difference. Besides, if the heading had showed up, it looks like it wouldn't have had the proper wrapper anyway.

As I understand it the "shared section" machinery is just a mechanism for cross-document reuse in the Sanity studio, it doesn't correspond to a semantic grouping on a user-facing level. So that's another reason I suspect removing the heading is the right thing.

## Testing this PR
1. Open the [front page](https://structured-content-2022-web-git-remove-shared-section-heading.sanity.build/)
2. Inspect the HTML DOM and/or View Source, and verify that there isn't a bunch of empty `<h2>` elements (compare with the current staging)