### PR TITLE
Fetch `sponsors`, `allSponsors` for `sponsorsSection` in non-reference `sections`

### DIFF
--- a/web/components/TextBlock/SponsorsSection/SponsorsSection.tsx
+++ b/web/components/TextBlock/SponsorsSection/SponsorsSection.tsx
@@ -1,4 +1,4 @@
-import { PortableTextComponentProps } from '@portabletext/react/dist/react-portable-text.esm';
+import { PortableTextComponentProps } from '@portabletext/react';
 import { Sponsor as TSponsor } from '../../../types/Sponsor';
 import { Sponsorship } from '../../../types/Sponsorship';
 import { EntitySectionSelection } from '../../../types/EntitySectionSelection';
@@ -28,6 +28,13 @@ export const SponsorsSection = ({
   }
 
   if (type === 'highlighted') {
+    if (!Array.isArray(sponsors) || sponsors.length === 0) {
+      console.error(
+        `SponsorsSection(type: 'highlighted') missing or invalid sponsors array: '${sponsors}'`
+      );
+      return null;
+    }
+
     return (
       <GridWrapper>
         <section className={styles.sponsorLevel}>

--- a/web/pages/[[...slug]].tsx
+++ b/web/pages/[[...slug]].tsx
@@ -88,6 +88,11 @@ const QUERY = groq`
               sponsors[]->,
               "allSponsorships": *[_id == "${mainEventId}"][0].sponsorships[]->,
             },
+            _type == "sponsorsSection" => {
+              ...,
+              sponsors[]->,
+              "allSponsorships": *[_id == "${mainEventId}"][0].sponsorships[]->,
+            },
             content[] {
               ...,
               reference->,


### PR DESCRIPTION
# Fetch`sponsors`, `allSponsors` for `sponsorsSection` in non-reference `sections`

## Intent

- Fetches `sponsors`, `allSponsors` for `sponsorsSection` in non-reference `sections`
  - To be quite honest, I don't really know what makes a reference section and not, and why we have to have this duplication of fetching related `allXXX` entities in the `QUERY`. There's probably a prettier way to write that whole query...
- Fixes rendering of "highlighted" Sponsors in _SponsorSection.tsx_; render `null` if `sponsors` array is empty


## Testing this PR

Verify that [/sponsorship-information](https://structured-content-2022-web-c56n1er1q.sanity.build/sponsorship-information) does not crash or render an empty, gray box.

