### PR TITLE
Twitter meta tags

### DIFF
--- a/web/pages/[[...slug]].tsx
+++ b/web/pages/[[...slug]].tsx
@@ -216,6 +216,11 @@ const Route = ({
               }
             : undefined
         }
+        twitter={{
+          cardType: image ? 'summary_large_image' : 'summary',
+          site: '@sanity_io',
+          handle: '@sanity_io',
+        }}
       />
       <header className={headerClasses}>
         <Nav


### PR DESCRIPTION
# Twitter meta tags

## Intent

Add Twitter meta tags that already [are present on `main`](https://github.com/sanity-io/structured-content-2022/blob/main/web/pages/index.tsx#L48-L51).

## Details 

Note that not all tags are explicitly added [because Twitter reads the equvalent `og:XXX` tags.](https://github.com/garmeeh/next-seo#twitter)

## Testing this PR

Verify that this PR's [Preview Deploy](https://structured-content-2022-web-junylfy8e.sanity.build/) renders the same tags as (or equivalents to) [the Twitter tags on `main`.](https://github.com/sanity-io/structured-content-2022/blob/main/web/pages/index.tsx#L48-L51)