### PR TITLE
Editorial articles accessible from root

### DIFF
--- a/web/components/MetaTags/MetaTags.tsx
+++ b/web/components/MetaTags/MetaTags.tsx
@@ -1,0 +1,52 @@
+import { NextSeo } from 'next-seo';
+import urlJoin from 'proper-url-join';
+import { imageUrlFor } from '../../lib/sanity';
+
+interface MetaTagsProps {
+  title: string;
+  description: string;
+  image?: object;
+  currentPath: string;
+  noIndex?: boolean;
+  rewrittenArticleSlugs?: string[];
+}
+
+export const MetaTags = ({
+  title,
+  description,
+  image,
+  currentPath,
+  noIndex,
+  rewrittenArticleSlugs,
+}: MetaTagsProps) => {
+  const isRewrittenPath =
+    Array.isArray(rewrittenArticleSlugs) &&
+    rewrittenArticleSlugs.includes(
+      urlJoin(currentPath, { leadingSlash: false })
+    );
+  const canonicalPath = isRewrittenPath
+    ? urlJoin('article', currentPath)
+    : currentPath;
+  return (
+    <NextSeo
+      title={title}
+      description={description}
+      canonical={urlJoin('https://structuredcontent.live', canonicalPath)}
+      noindex={noIndex}
+      openGraph={
+        image
+          ? {
+              images: [
+                {
+                  url: imageUrlFor(image)
+                    .ignoreImageParams()
+                    .size(1260, 630)
+                    .url(),
+                },
+              ],
+            }
+          : undefined
+      }
+    />
+  );
+};

--- a/web/components/MetaTags/index.ts
+++ b/web/components/MetaTags/index.ts
@@ -1,0 +1,1 @@
+export { MetaTags as default } from './MetaTags';

--- a/web/next.config.js
+++ b/web/next.config.js
@@ -31,9 +31,11 @@ module.exports = {
     ];
   },
   async rewrites() {
-    const articleSlugs = await client.fetch(`*[_type == "article"].slug.current`);
+    const articleSlugs = await client.fetch(
+      `*[_type == "article"].slug.current`
+    );
     if (!Array.isArray(articleSlugs) || !articleSlugs.length) {
-      console.error("Next.js rewrites: could not find any Editorial Articles!");
+      console.error('Next.js rewrites: could not find any Editorial Articles!');
       return [];
     }
 
@@ -43,7 +45,9 @@ module.exports = {
     }));
 
     console.log(`Rewriting ${rewrites.length} article slugs:`);
-    rewrites.forEach((rewrite) => console.log(rewrite.source, '->', rewrite.destination));
+    rewrites.forEach((rewrite) =>
+      console.log(rewrite.source, '->', rewrite.destination)
+    );
     return rewrites;
-  }
+  },
 };

--- a/web/next.config.js
+++ b/web/next.config.js
@@ -32,7 +32,12 @@ module.exports = {
   },
   async rewrites() {
     const articleSlugs = await client.fetch(`*[_type == "article"].slug.current`);
-    const rewrites = articleSlugs.map((slug) => ({
+    if (!Array.isArray(articleSlugs) || !articleSlugs.length) {
+      console.error("Next.js rewrites: could not find any Editorial Articles!");
+      return [];
+    }
+
+    const rewrites = articleSlugs.filter(Boolean).map((slug) => ({
       source: `/${slug}`,
       destination: `/article/${slug}`,
     }));

--- a/web/next.config.js
+++ b/web/next.config.js
@@ -30,4 +30,15 @@ module.exports = {
       },
     ];
   },
+  async rewrites() {
+    const articleSlugs = await client.fetch(`*[_type == "article"].slug.current`);
+    const rewrites = articleSlugs.map((slug) => ({
+      source: `/${slug}`,
+      destination: `/article/${slug}`,
+    }));
+
+    console.log(`Rewriting ${rewrites.length} article slugs:`);
+    rewrites.forEach((rewrite) => console.log(rewrite.source, '->', rewrite.destination));
+    return rewrites;
+  }
 };

--- a/web/pages/[[...slug]].tsx
+++ b/web/pages/[[...slug]].tsx
@@ -1,7 +1,5 @@
 import clsx from 'clsx';
 import { groq } from 'next-sanity';
-import { NextSeo } from 'next-seo';
-import urlJoin from 'proper-url-join';
 import { useEffect, useState } from 'react';
 import Hero from '../components/Hero';
 import TextBlock from '../components/TextBlock';
@@ -10,13 +8,13 @@ import ConferenceHeader from '../components/ConferenceHeader';
 import NavBlock from '../components/NavBlock';
 import Footer from '../components/Footer';
 import Nav from '../components/Nav';
+import MetaTags from '../components/MetaTags';
 import client from '../lib/sanity.server';
 import { Slug } from '../types/Slug';
 import { Section } from '../types/Section';
 import { Hero as HeroProps } from '../types/Hero';
 import { mainEventId } from '../util/entityPaths';
 import styles from './app.module.css';
-import { imageUrlFor } from '../lib/sanity';
 
 const QUERY = groq`
   {
@@ -158,7 +156,7 @@ interface RouteProps {
 const Route = ({
   data: {
     route: {
-      page: { name, hero, sections },
+      page: { hero, sections },
       seo: { title, description: seoDescription, image, noIndex },
     },
     home: { name: homeName, startDate, endDate, description, ticketsUrl },
@@ -197,25 +195,8 @@ const Route = ({
 
   return (
     <>
-      <NextSeo
-        title={title}
-        description={seoDescription}
-        canonical={urlJoin('https://structuredcontent.live', currentPath)}
-        noindex={noIndex}
-        openGraph={
-          image
-            ? {
-                images: [
-                  {
-                    url: imageUrlFor(image)
-                      .ignoreImageParams()
-                      .size(1260, 630)
-                      .url(),
-                  },
-                ],
-              }
-            : undefined
-        }
+      <MetaTags
+        {...{ title, description: seoDescription, image, currentPath, noIndex }}
       />
       <header className={headerClasses}>
         <Nav

--- a/web/pages/article/[slug].tsx
+++ b/web/pages/article/[slug].tsx
@@ -1,17 +1,16 @@
-import clsx from 'clsx';
 import { groq } from 'next-sanity';
-import { useEffect, useState } from 'react';
 import Hero from '../../components/Hero';
 import TextBlock from '../../components/TextBlock';
 import Footer from '../../components/Footer';
 import Nav from '../../components/Nav';
 import client from '../../lib/sanity.server';
 import { Slug } from '../../types/Slug';
-import styles from '../app.module.css';
-import articleStyles from './article.module.css';
 import { mainEventId } from '../../util/entityPaths';
 import GridWrapper from '../../components/GridWrapper';
 import { Article } from '../../types/Article';
+import articleStyles from './article.module.css';
+import styles from '../app.module.css';
+import MetaTags from '../../components/MetaTags';
 
 const QUERY = groq`
   {
@@ -26,6 +25,7 @@ const QUERY = groq`
         _id,
       }
     },
+    "rewrittenArticleSlugs": *[_type == "article"].slug.current,
   }`;
 
 interface ArticleRouteProps {
@@ -41,6 +41,7 @@ interface ArticleRouteProps {
         _id: string;
       }[];
     };
+    rewrittenArticleSlugs?: string[];
   };
   slug: string;
 }
@@ -50,10 +51,17 @@ const ArticleRoute = ({
     article: { heading, summary, content },
     home: { ticketsUrl },
     footer,
+    rewrittenArticleSlugs,
   },
   slug,
 }: ArticleRouteProps) => (
   <>
+    <MetaTags
+      title={heading}
+      description={summary}
+      currentPath={slug}
+      rewrittenArticleSlugs={rewrittenArticleSlugs}
+    />
     <header className={styles.header}>
       <Nav
         onFrontPage={false}


### PR DESCRIPTION
# Editorial articles accessible from root 

## Intent

Solves [this](https://app.shortcut.com/sanity-io/story/15481/routing-update-to-handle-editorial-articles) Shortcut Story, which calls for Editorial Articles being accessible from both _/:slug_ and _/article/:slug_ routes.

## Description

On startup, we now fetch all available `article` documents and add them to Next.js' [`rewrite`](https://nextjs.org/docs/api-reference/next.config.js/rewrites) config. 

I don't think this array is ever updated post-deployment, so [the relevant Shortcut Story](https://app.shortcut.com/sanity-io/story/14538/rebuild-page-when-respective-sanity-content-is-updated) should also update this setting if any article is added/removed. 

## Testing this PR

1. Verify that the build logs for this branch log (three, at the time of writing) rewrites being added 
2. Visit an article from root, e.g. [/code-of-conduct](https://structured-content-2022-web-m5ams3t6l.sanity.build/code-of-conduct) and verify that you're presented with the same content as if you'd accessed [/article/code-of-conduct](https://structured-content-2022-web-m5ams3t6l.sanity.build/article/code-of-conduct)
3. Verify that the `canonical` meta tag points to `https://structuredcontent.live/article/code-of-conduct`, including the `/article` bit
4. Verify that meta tags render correctly when accessing articles both from _/:slug_ and _/article/:slug_