### PR TITLE
Tickets expiry

### DIFF
--- a/web/components/TextBlock/Tickets/Tickets.module.css
+++ b/web/components/TextBlock/Tickets/Tickets.module.css
@@ -42,6 +42,14 @@
   color: var(--color-material-gray-600);
 }
 
+.visuallyHidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  clip: rect(1px, 1px, 1px, 1px);
+  overflow: hidden;
+}
+
 .price {
   margin: 0 0 8px;
   color: var(--color-brand-black);

--- a/web/components/TextBlock/Tickets/Tickets.module.css
+++ b/web/components/TextBlock/Tickets/Tickets.module.css
@@ -44,17 +44,16 @@
 
 .price {
   margin: 0 0 8px;
-  text-decoration: line-through;
-  color: var(--color-material-gray-600);
+  color: var(--color-brand-black);
 }
 
 .price:last-child {
   margin: 0;
 }
 
-.price.current {
-  text-decoration: none;
-  color: var(--color-brand-black);
+.price.expired {
+  text-decoration: line-through;
+  color: var(--color-material-gray-600);
 }
 
 .ticketFeatures {

--- a/web/components/TextBlock/Tickets/Tickets.tsx
+++ b/web/components/TextBlock/Tickets/Tickets.tsx
@@ -81,7 +81,11 @@ export const Tickets = ({
                       ({ _key, label, price, isExpired, expires }) => (
                         <Fragment key={_key}>
                           <dt className={styles.priceLabel}>
-                            Price {label ? `(${label})` : null}
+                            {label || (
+                              <span className={styles.visuallyHidden}>
+                                Price
+                              </span>
+                            )}
                           </dt>
                           {isExpired ? (
                             <dd className={clsx(styles.price, styles.expired)}>
@@ -160,7 +164,9 @@ export const Tickets = ({
                     ({ _key, label, price, isExpired, expires }) => (
                       <Fragment key={_key}>
                         <dt className={styles.priceLabel}>
-                          Price {label ? `(${label})` : null}
+                          {label || (
+                            <span className={styles.visuallyHidden}>Price</span>
+                          )}
                         </dt>
                         {isExpired ? (
                           <dd className={clsx(styles.price, styles.expired)}>

--- a/web/components/TextBlock/Tickets/Tickets.tsx
+++ b/web/components/TextBlock/Tickets/Tickets.tsx
@@ -1,5 +1,8 @@
 import clsx from 'clsx';
 import { compareAsc, parseISO } from 'date-fns';
+import enUS from 'date-fns/locale/en-US';
+import sub from 'date-fns/sub';
+import { format } from 'date-fns-tz';
 import { PortableText, PortableTextComponentProps } from '@portabletext/react';
 import { Fragment } from 'react';
 import checkmarkIcon from '../../../images/checkmark.svg';
@@ -61,6 +64,19 @@ export const Tickets = ({
     });
   };
 
+  const expiryString = (timestamp: Date): string => {
+    /* TODO: investigate if this is safe to do or if it needs to be done in a
+     * way that is aware of the PST timezone, in case of daylight saving corner
+     * cases
+     */
+    const oneDayBeforeExpiry = sub(timestamp, { days: 1 });
+    const formattedDay = format(oneDayBeforeExpiry, 'MMMM d', {
+      timeZone: 'PST8PDT',
+      locale: enUS,
+    });
+    return ` (thru ${formattedDay})`;
+  };
+
   return (
     <GridWrapper>
       <table className={styles.table}>
@@ -86,6 +102,7 @@ export const Tickets = ({
                                 Price
                               </span>
                             )}
+                            {expires && expiryString(expires)}
                           </dt>
                           {isExpired ? (
                             <dd className={clsx(styles.price, styles.expired)}>
@@ -167,6 +184,7 @@ export const Tickets = ({
                           {label || (
                             <span className={styles.visuallyHidden}>Price</span>
                           )}
+                          {expires && expiryString(expires)}
                         </dt>
                         {isExpired ? (
                           <dd className={clsx(styles.price, styles.expired)}>

--- a/web/package.json
+++ b/web/package.json
@@ -12,6 +12,7 @@
     "@sanity/client": "^3.0.3",
     "clsx": "^1.1.1",
     "date-fns": "^2.28.0",
+    "date-fns-tz": "^1.3.0",
     "next": "12.0.8",
     "next-sanity": "^0.4.0",
     "next-seo": "^5.1.0",

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -672,6 +672,11 @@ damerau-levenshtein@^1.0.7:
   resolved "https://registry.yarnpkg.com/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz#b43d286ccbd36bc5b2f7ed41caf2d0aba1f8a6e7"
   integrity sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==
 
+date-fns-tz@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/date-fns-tz/-/date-fns-tz-1.3.0.tgz#6c83d4bdf20d54060cf176d96a3ca45043b36a84"
+  integrity sha512-r6ye6PmGEvkF467/41qzU71oGwv9kHTnV3vtSZdyV6VThwPID47ZH7FtR7zQWrhgOUWkYySm2ems2w6ZfNUqoA==
+
 date-fns@^2.28.0:
   version "2.28.0"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.28.0.tgz#9570d656f5fc13143e50c975a3b6bbeb46cd08b2"


### PR DESCRIPTION
# Tickets expiry

## Intent

Change the rendering of price points in the Tickets section as described in [Shortcut](https://app.shortcut.com/sanity-io/story/15373/all-tickets-table-presentation-fix-pre-launch)

## Description

- Stops crossing out prices whose `availableFrom` time has not yet been reached
- Instead starts crossing out prices that are expired, where the expiry time is determined based on the ticket that's next in line in `availableFrom` order, if any (a ticket is expired if another ticket is available)
- Changes the output format from e.g. "Price (Early-bird)" to "Early-bird (thru March 31)" where the date is determined based on the aforementioned expiry time and is shown in the PST timezone. The super-specific spec on this is a bit unclear, but here I'm basically subtracting one "day" (however `date-fns` interprets that) so that if the timestamp is set somewhere during 2021-04-01 in PST timezone, the intention is that the resulting string will be "thru March 31" (i.e. it's "thru" the day in which the ticket is completely available, not the day in which it may be partially available)

I'm not familiar with date-fns from before, so I'm not sure what's the ideal way to solve it, but this is what I ended up with based on the docs. Tips would be welcome if there are better ways. I also ended up importing a second date-fns-based library for the timezone part… hopefully still OK for performance since it seems to be relying on browser-native timezone data? I see no difference in Lighthouse compared to staging with a very small sample size of 2–3 reloads.

## Testing this PR
1. Open https://structured-content-2022-web-git-tickets-expiry.sanity.build/registration-info
2. Scroll down to the table; verify that it says "Early-bird (thru March 31)" and that none of the prices have strikethrough style
3. Optional: modify the ticket data (either by temporarily changing the production dataset or by modifying the code locally) and set a "Standard" price point to be availableFrom yesterday, and verify that the corresponding "early-bird" becomes crossed out