### PR TITLE
Program venue updates

### DIFF
--- a/web/components/TextBlock/Programs/Programs.tsx
+++ b/web/components/TextBlock/Programs/Programs.tsx
@@ -45,7 +45,7 @@ export const Programs = ({
               content: (
                 <div key={program._id}>
                   <h3 className={clsx(styles.dayHeader, styles.first)}>
-                    {formatDateWithDay(program.startDateTime)}
+                    {formatDateWithDay(program.startDateTime, timezone)}
                   </h3>
                   {program.sessions.map((session, index) => {
                     const Session = (
@@ -56,19 +56,25 @@ export const Programs = ({
                               addMinutes(
                                 currentTime,
                                 session.duration
-                              ).toISOString()
+                              ).toISOString(),
+                              timezone
                             )}
                           </h3>
                         ) : (
                           <>
                             <div className={styles.sessionItem}>
                               <h4 className={styles.sessionDuration}>
-                                {formatTime(currentTime.toISOString())} -{' '}
+                                {formatTime(
+                                  currentTime.toISOString(),
+                                  timezone
+                                )}{' '}
+                                -{' '}
                                 {formatTime(
                                   addMinutes(
                                     currentTime,
                                     session.session.duration
-                                  ).toISOString()
+                                  ).toISOString(),
+                                  timezone
                                 )}
                               </h4>
                               <div>{session.session.title}</div>

--- a/web/components/TextBlock/Programs/Programs.tsx
+++ b/web/components/TextBlock/Programs/Programs.tsx
@@ -4,7 +4,11 @@ import { PortableTextComponentProps } from '@portabletext/react';
 import clsx from 'clsx';
 import { EntitySectionSelection } from '../../../types/EntitySectionSelection';
 import { Program } from '../../../types/Program';
-import { formatDateWithDay, formatTime } from '../../../util/date';
+import {
+  formatDateWithDay,
+  formatTime,
+  getNonLocationTimezone,
+} from '../../../util/date';
 import Accordion from '../../Accordion';
 import GridWrapper from '../../GridWrapper';
 import styles from './Programs.module.css';
@@ -26,13 +30,18 @@ export const Programs = ({
           items={allPrograms.map((program) => {
             const firstVenue = program?.venues[0];
             const programName = firstVenue?.name || program.internalName;
+            const timezone = firstVenue?.timezone || 'UTC';
             let currentTime = parseISO(program.startDateTime);
+            const formattedTimezone = getNonLocationTimezone(
+              program.startDateTime,
+              timezone
+            );
             /* This should perhaps be outputting a list instead, i.e. a <dl>
              * or <ul>, rather than a lot of <h4>s. Not done due to dev time
              * constraints.
              */
             return {
-              title: programName,
+              title: `${programName} - ${formattedTimezone}`,
               content: (
                 <div key={program._id}>
                   <h3 className={clsx(styles.dayHeader, styles.first)}>

--- a/web/components/TextBlock/Programs/Programs.tsx
+++ b/web/components/TextBlock/Programs/Programs.tsx
@@ -24,13 +24,15 @@ export const Programs = ({
         <Accordion
           baseId={`accordion-${index}`}
           items={allPrograms.map((program) => {
+            const firstVenue = program?.venues[0];
+            const programName = firstVenue?.name || program.internalName;
             let currentTime = parseISO(program.startDateTime);
             /* This should perhaps be outputting a list instead, i.e. a <dl>
              * or <ul>, rather than a lot of <h4>s. Not done due to dev time
              * constraints.
              */
             return {
-              title: program.internalName,
+              title: programName,
               content: (
                 <div key={program._id}>
                   <h3 className={clsx(styles.dayHeader, styles.first)}>

--- a/web/components/TextBlock/Programs/Programs.tsx
+++ b/web/components/TextBlock/Programs/Programs.tsx
@@ -33,7 +33,7 @@ export const Programs = ({
             const timezone = firstVenue?.timezone || 'UTC';
             let currentTime = parseISO(program.startDateTime);
             const formattedTimezone = getNonLocationTimezone(
-              program.startDateTime,
+              currentTime,
               timezone
             );
             /* This should perhaps be outputting a list instead, i.e. a <dl>

--- a/web/types/Venue.ts
+++ b/web/types/Venue.ts
@@ -9,4 +9,5 @@ export type Venue = {
     lng: number;
   };
   slug: Slug;
+  timezone?: string;
 };

--- a/web/util/date.ts
+++ b/web/util/date.ts
@@ -1,9 +1,5 @@
-import { format } from 'date-fns';
 import { formatInTimeZone } from 'date-fns-tz';
 import enUS from 'date-fns/locale/en-US';
-
-export const formatDateWithTime = (date: string) =>
-  format(new Date(date), 'MMMM d, yyyy');
 
 export const formatTime = (date: string, timezone: string) =>
   formatInTimeZone(new Date(date), timezone, 'HH:mm', { locale: enUS });

--- a/web/util/date.ts
+++ b/web/util/date.ts
@@ -5,10 +5,11 @@ import enUS from 'date-fns/locale/en-US';
 export const formatDateWithTime = (date: string) =>
   format(new Date(date), 'MMMM d, yyyy');
 
-export const formatTime = (date: string) => format(new Date(date), 'HH:mm');
+export const formatTime = (date: string, timezone: string) =>
+  formatInTimeZone(new Date(date), timezone, 'HH:mm', { locale: enUS });
 
-export const formatDateWithDay = (date: string) =>
-  format(new Date(date), 'eeee – MMMM d');
+export const formatDateWithDay = (date: string, timezone: string) =>
+  formatInTimeZone(new Date(date), timezone, 'eeee – MMMM d', { locale: enUS });
 
 const monthNames = [
   'January',

--- a/web/util/date.ts
+++ b/web/util/date.ts
@@ -1,4 +1,6 @@
 import { format } from 'date-fns';
+import { formatInTimeZone } from 'date-fns-tz';
+import enUS from 'date-fns/locale/en-US';
 
 export const formatDateWithTime = (date: string) =>
   format(new Date(date), 'MMMM d, yyyy');
@@ -48,3 +50,14 @@ export const formatDateRangeInUtc = (
     end: `${m2}${d2.day}, ${d2.year}`,
   };
 };
+
+/* Converts an IANA time zone name, which typically refers to a specific city,
+ * into a long-form "non-location" format.
+ * Example: given the locationTimezone "Europe/Paris", this will yield "Central
+ * European Time" or "Central European Summer Time" depending on the timestamp.
+ */
+export const getNonLocationTimezone = (
+  timestamp: Date,
+  locationTimezone: string
+): string =>
+  formatInTimeZone(timestamp, locationTimezone, 'zzzz', { locale: enUS });


### PR DESCRIPTION
# Program venue updates

## Intent

Update Program section to use the program venue's timezone when listing out the sessions, reflecting this in the program's heading. See [Shortcut story "Update program page"](https://app.shortcut.com/sanity-io/story/15643/update-program-page).

## Description

This is using date-fns-tz, just like an earlier [PR for Tickets](https://github.com/sanity-io/structured-content-2022/pull/80). Timezone is defined on a venue in Sanity. As discussed in video meeting with Sanity yesterday, we can assume that a program will only have one venue (even though their data model supports multiple).

Sketches in Figma display the time zone as a long-form location-independent string, so e.g. "British Summer Time", not "Europe/London". This representation varies based on time. In the edge case where the program spans two different such time zone representations (due to daylight saving time switch), the program heading just shows the timezone that applies at the program's start. I figure that's close enough.

As requested in the Shortcut story, this PR also changes the heading from using the internal program name to using the (first) venue's name (which is shorter). It does not include solving the order of programs, however, since I think this requires some sort of sorting data to be specified in the schema, which would be up to Knut. I'll ping Celine about that.

## Testing this PR
1. Open the [Program page](https://structured-content-2022-web-git-program-venue-updates.sanity.build/program)
2. Verify that the headings include venue name and timezone, e.g. "New York - Eastern Daylight Time" and not "New York City" (or "Oslo 2022")
3. Verify that the days and times specified in each program are given in the indicated timezone, e.g. PDT for the San Fransisco sessions. (I used "Inspect" in the studio for this purpose to see the exact timestamp that was given for `startDateTime`, and [timeanddate.com](https://www.timeanddate.com/time/zones/pdt) to see which offsets the American cities are at. Or, as far as I can see, if you look at the displayed date+time in Sanity, that seems to be using your local timezone.)