### PR TITLE
Update nav links

### DIFF
--- a/web/components/Nav/Nav.module.css
+++ b/web/components/Nav/Nav.module.css
@@ -129,9 +129,10 @@
   }
 
   .link {
-    font: var(--font-display-lg);
-    letter-spacing: normal;
-    display: inline;
+    font: var(--font-display-base);
+    letter-spacing: -0.01em;
+    display: inline-block; /* 'block' would make blank space be clickable */
+    margin: 0 0 8px;
   }
 }
 

--- a/web/components/Nav/Nav.tsx
+++ b/web/components/Nav/Nav.tsx
@@ -93,7 +93,10 @@ export const Nav = ({ onFrontPage, currentPath, ticketsUrl }: NavProps) => {
               urlPath="/sponsorship-information"
               label="Sponsorship"
             />
-            <BasicMenuItem urlPath="/venues" label="Venues" />
+            <BasicMenuItem
+              urlPath="/registration-info"
+              label="Registration info"
+            />
             <BasicMenuItem urlPath="/about" label="About" />
           </ul>
           <div className={styles.ticketButton}>

--- a/web/components/NavBlock/NavBlock.tsx
+++ b/web/components/NavBlock/NavBlock.tsx
@@ -44,18 +44,25 @@ export const NavBlock = ({ ticketsUrl }: NavBlockProps) => (
 
       <FakeItem mobile tablet desktop />
       <FakeItem mobile tablet desktop shape="Plus" />
-      <FakeItem tablet desktop />
+      <FakeItem divider mobile />
+      <FakeItem mobile />
+
+      <li className={styles.item}>
+        <Link href="/sponsorship-information">
+          <a className={styles.link}>Sponsorship</a>
+        </Link>
+      </li>
+
       <FakeItem tablet desktop />
       <FakeItem divider mobile tablet desktop />
       <FakeItem tablet desktop />
       <FakeItem tablet desktop shape="C" />
       <FakeItem tablet desktop />
       <FakeItem mobile tablet desktop shape="Ovals" />
-      <FakeItem mobile />
 
       <li className={styles.item}>
-        <Link href="/speakers">
-          <a className={styles.link}>Speakers</a>
+        <Link href="/registration-info">
+          <a className={styles.link}>Registration info</a>
         </Link>
       </li>
 
@@ -74,7 +81,7 @@ export const NavBlock = ({ ticketsUrl }: NavBlockProps) => (
 
       <li className={styles.item}>
         <Link href={ticketsUrl}>
-          <a className={styles.link}>Early-bird tickets</a>
+          <a className={styles.link}>Tickets</a>
         </Link>
       </li>
 


### PR DESCRIPTION
# Update nav links

## Intent

Update the links in the main navigation components (header `Nav` and frontpage `NavBlock`) as specified in [Shortcut](https://app.shortcut.com/sanity-io/story/15483/update-nav-block-and-header-nav-with-the-correct-links). Basically, "Venues" is replaced by "Registration info" in the main header menu (`Nav`), and the NavBlock—i.e. yellow boxes on the front page—is updated so that the links are the same as for Nav.

## Description

As discussed in Shortcut, the longer link texts didn't fit inside the viewport in some cases (e.g. 320px width), so the styling of those texts has been updated. Other than that it should be pretty straightforward.

## Testing this PR
1. Open the [front page](https://structured-content-2022-web-git-update-nav-links.sanity.build/)
2. Scroll down to the yellow boxes below the logo+intro
3. Verify that those "nav block" boxes contain "Sponsorship" and "Registration info", but not "Speakers" (and optionally compare to the current Figma sketches for the various breakpoints)
4. Verify that the header menu bar (which eventually pops up if you scroll down far enough on desktop) contains all the same links as the nav block ("Tickets" being a special case on desktop, it appears as a CTA "button")