### PR TITLE
Hardcoded conference dates

### DIFF
--- a/web/components/ConferenceHeader/ConferenceHeader.module.css
+++ b/web/components/ConferenceHeader/ConferenceHeader.module.css
@@ -31,11 +31,6 @@
     column-gap: var(--grid-medium-gutter);
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
-
-  .datesAndHostedByWrapper {
-    font: var(--font-body-xl-medium);
-    letter-spacing: var(--letter-spacing-body-xl);
-  }
 }
 
 @media (--large-up) {
@@ -51,7 +46,7 @@
   }
 
   .datesAndHostedByWrapper {
-    font: var(--font-ui-xxl-medium);
-    letter-spacing: var(--letter-spacing-ui-xxl);
+    font: var(--font-ui-xl-medium);
+    letter-spacing: var(--letter-spacing-ui-xl);
   }
 }

--- a/web/components/ConferenceHeader/ConferenceHeader.tsx
+++ b/web/components/ConferenceHeader/ConferenceHeader.tsx
@@ -29,9 +29,8 @@ export const ConferenceHeader = ({
       </h1>
       <div className={styles.summary}>
         <div className={styles.datesAndHostedByWrapper}>
-          <p className={styles.dates}>
-            <DateRange startTimestamp={startDate} endTimestamp={endDate} />
-          </p>
+          <p className={styles.dates}>US: May 24–25, 2022</p>
+          <p className={styles.dates}>UK &amp; Europe: May 25–26, 2022</p>
           <p className={styles.hostedBy}>Hosted by Sanity</p>
         </div>
         <p className={styles.description}>{description}</p>

--- a/web/components/ConferenceHeader/ConferenceHeader.tsx
+++ b/web/components/ConferenceHeader/ConferenceHeader.tsx
@@ -3,15 +3,11 @@ import styles from './ConferenceHeader.module.css';
 
 interface ConferenceHeaderProps {
   name?: string;
-  startDate?: string;
-  endDate?: string;
   description?: string;
 }
 
 export const ConferenceHeader = ({
   name,
-  startDate,
-  endDate,
   description,
 }: ConferenceHeaderProps) => {
   return (

--- a/web/components/ConferenceHeader/ConferenceHeader.tsx
+++ b/web/components/ConferenceHeader/ConferenceHeader.tsx
@@ -1,6 +1,5 @@
 import logo from '../../images/logo.svg';
 import styles from './ConferenceHeader.module.css';
-import DateRange from '../DateRange';
 
 interface ConferenceHeaderProps {
   name?: string;

--- a/web/pages/[[...slug]].tsx
+++ b/web/pages/[[...slug]].tsx
@@ -115,8 +115,6 @@ const QUERY = groq`
     },
     "home": *[_id == "${mainEventId}"][0] {
       name,
-      startDate,
-      endDate,
       description,
       "ticketsUrl": microcopy[key == "mainCta"][0].action,
     },
@@ -147,8 +145,6 @@ interface RouteProps {
     };
     home: {
       name: string;
-      startDate: string;
-      endDate: string;
       description: string;
       ticketsUrl: string;
     };
@@ -171,7 +167,7 @@ const Route = ({ data: initialData, slug, preview }: RouteProps) => {
         page: { hero, sections },
         seo: { title, description: seoDescription, image, noIndex },
       },
-      home: { name: homeName, startDate, endDate, description, ticketsUrl },
+      home: { name: homeName, description, ticketsUrl },
       footer,
     },
   } = usePreviewSubscription(QUERY, {
@@ -224,12 +220,7 @@ const Route = ({ data: initialData, slug, preview }: RouteProps) => {
       <main>
         {slug === '/' ? (
           <GridWrapper>
-            <ConferenceHeader
-              name={homeName}
-              startDate={startDate}
-              endDate={endDate}
-              description={description}
-            />
+            <ConferenceHeader name={homeName} description={description} />
             <NavBlock ticketsUrl={ticketsUrl} />
           </GridWrapper>
         ) : (

--- a/web/styles/variables.css
+++ b/web/styles/variables.css
@@ -29,6 +29,7 @@
   --font-display-xs: 700 28px/35px 'National 2 Narrow', sans-serif;
   --font-display-xxs: 700 24px/30px 'National 2 Narrow', sans-serif;
   --font-ui-sm-medium: 500 16px/22px 'Inter', sans-serif;
+  --font-ui-xl-medium: 500 30px/38px 'Inter', sans-serif;
   --font-ui-xxl-medium: 500 40px/56px 'Inter', sans-serif;
   --grid-gutter: 40px;
   --grid-half-gutter: 20px;
@@ -40,6 +41,7 @@
   --letter-spacing-body-large: -0.017em;
   --letter-spacing-body-xl: -0.019em;
   --letter-spacing-ui-sm: -0.011em;
+  --letter-spacing-ui-xl: -0.021em;
   --letter-spacing-ui-xxl: -0.022em;
   --max-body-text-width: 37.5rem;
   --spacing-small: 40px;


### PR DESCRIPTION
# Hardcoded conference dates

## Intent

Replace the current UTC display of the conference start/end timestamps (which were fetched from Sanity) with two hardcoded sets of start/end dates for the Structured Content 2022 conference specifically—one line for US and one for UK&Europe. As specified in [Shortcut](https://app.shortcut.com/sanity-io/story/14897/home-page-presentation-of-dates-across-timezones)

## Description

As discussed in the Shortcut story (and way back on video with Knut), presenting such semi-localized dates based on a single pair of start/end timestamps isn't necessarily realistic (does the conference really start and end simultaneously world-wide, or is it actually a moving "window"…) Furthermore, according to the story, this conference might be an exception, so it has been decided that we'll hardcode it for now and possibly revisit later.

Because of the increased lengths of these strings, the font size has been turned down as per the Figma sketches.

## Testing this PR
1. Open the [front page](https://structured-content-2022-web-bc2dmjic9.sanity.build/)
2. Verify that the start/end dates shown directly below the big conference logo are now shown in two separate paragraphs, one for "US" and one for "UK & Europe", as per the sketches in Shortcut/Figma