### PR TITLE
Tickets quickfixes

### DIFF
--- a/web/components/TextBlock/Tickets/Tickets.module.css
+++ b/web/components/TextBlock/Tickets/Tickets.module.css
@@ -83,7 +83,6 @@
 
 .includedFeatureDescription {
   padding-left: 12px;
-  text-transform: capitalize;
 }
 
 .feature,
@@ -98,7 +97,6 @@
 .feature {
   font: inherit;
   text-align: left;
-  text-transform: capitalize;
 }
 
 .featurePresence {

--- a/web/components/TextBlock/Tickets/Tickets.module.css
+++ b/web/components/TextBlock/Tickets/Tickets.module.css
@@ -30,7 +30,7 @@
 .name {
   margin: 0 0 4px;
   font: var(--font-body-large-bold);
-  letter-spacing: var(--font-body-large);
+  letter-spacing: var(--letter-spacing-body-large);
 }
 
 .priceList {


### PR DESCRIPTION
# Tickets quickfixes

## Intent

Changes a couple small things with the Tickets component:
- Fixes a warning that was caused by a copy/paste error on my part, resulting in an invalid letter-spacing declaration
- Removes some `text-transform` usage that was presumably done as a hack/workaround for ticket features previously being all lowercase in Sanity

## Description

I find it really hard to tell the difference between letter-spacing being present or absent here, not sure if it's just me or if it's invisible to the naked eye… Removing the warning was the main thing here.

As for the ticket features, this appears to have been fixed on the studio side in https://github.com/sanity-io/structured-content-2022/commit/a52c12d8a96a07c55497cb574ef473fd306d069c so I don't think we need any workaround anymore (if we did we should probably only transform `::first-letter`, or adjust the content itself instead of in the styling layer, so that e.g. copy/paste would work correctly in Firefox).

## Testing this PR
1. Open your web browser's dev tools and ensure that CSS warnings/errors are enabled in the console
2. Open the [front page](http://structured-content-2022-web-git-tickets-quickfixes.sanity.build/) and then [/registration-info](http://structured-content-2022-web-git-tickets-quickfixes.sanity.build/registration-info)
3. Verify that there is no message along the lines of `Error in parsing value for ‘letter-spacing’.  Declaration dropped.` (quoted wording is from Firefox, other browsers may vary) in the dev tools console
4. Scroll down to the event pricing table and verify that the row headers are capitalized correctly, e.g. saying "Recordings after the event" and not "Recordings After The Event"