### PR TITLE
Hotfix: render /terms-and-conditions

### DIFF
--- a/web/components/TextBlock/TextBlock/TextBlock.tsx
+++ b/web/components/TextBlock/TextBlock/TextBlock.tsx
@@ -43,7 +43,7 @@ const components: Partial<PortableTextComponents> = {
     code: ({ children }) => <code>{children}</code>,
     internalLink: ({ text, value }) => (
       /* href has been seen in a case where both link and internalLink marks applied */
-      <Link href={value?.href || getEntityPath(value)}>{text}</Link>
+      <Link href={value?.href || getEntityPath(value.reference)}>{text}</Link>
     ),
   },
 };

--- a/web/components/TextBlock/TextBlock/TextBlock.tsx
+++ b/web/components/TextBlock/TextBlock/TextBlock.tsx
@@ -42,6 +42,7 @@ const components: Partial<PortableTextComponents> = {
     underline: ({ children }) => <u>{children}</u>,
     code: ({ children }) => <code>{children}</code>,
     internalLink: ({ text, value }) => (
+      /* href has been seen in a case where both link and internalLink marks applied */
       <Link href={value?.href || getEntityPath(value)}>{text}</Link>
     ),
   },

--- a/web/components/TextBlock/TextBlock/TextBlock.tsx
+++ b/web/components/TextBlock/TextBlock/TextBlock.tsx
@@ -42,7 +42,7 @@ const components: Partial<PortableTextComponents> = {
     underline: ({ children }) => <u>{children}</u>,
     code: ({ children }) => <code>{children}</code>,
     internalLink: ({ text, value }) => (
-      <Link href={getEntityPath(value.reference)}>{text}</Link>
+      <Link href={value?.href || getEntityPath(value)}>{text}</Link>
     ),
   },
 };

--- a/web/util/entityPaths.ts
+++ b/web/util/entityPaths.ts
@@ -7,8 +7,8 @@ type Entity = Person | Session | Venue;
 
 export const mainEventId = 'aad77280-6394-4090-afad-1c0f2a0416c6';
 
-export const getEntityPath = (entity: Entity) => {
-  if (!entity.slug?.current) {
+export const getEntityPath = (entity?: Entity) => {
+  if (!entity?.slug?.current) {
     return '#';
   }
 


### PR DESCRIPTION
# Hotfix: render /terms-and-conditions

## Intent

Make /terms-and-conditions render again.

## Details

- "community@sanity.io" link [here](https://stagingadmin.structuredcontent.live/desk/article;8db38690-28be-4d0a-87fb-96f70b850d16) did not have a `href` set, which passed an `undefined` `entity` to _web/util/entityPaths.ts_.
- I fixed the link and published, but the link's href was still `#`; apparently `internalLink`s can have a `value.href`. Let's use this value if present

## Testing this PR

Verify that [/terms-and-conditions](https://structured-content-2022-web-2zq6bgbtz.sanity.build/terms-and-conditions) renders fine without any error/warning output to the console.
