### PR TITLE
TextAndImage.tsx: render Figure's alt text if present

### DIFF
--- a/web/components/TextBlock/TextAndImage/TextAndImage.tsx
+++ b/web/components/TextBlock/TextAndImage/TextAndImage.tsx
@@ -24,7 +24,7 @@ export const TextAndImage = ({
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
             src={imageUrlFor(image).ignoreImageParams().url()}
-            alt={image.alt}
+            alt={image.alt || ''}
             className={styles.image}
           />
         </div>

--- a/web/components/TextBlock/TextAndImage/TextAndImage.tsx
+++ b/web/components/TextBlock/TextAndImage/TextAndImage.tsx
@@ -1,5 +1,6 @@
 import { PortableTextComponentProps } from '@portabletext/react';
 import { imageUrlFor } from '../../../lib/sanity';
+import { Figure } from "../../../types/Figure";
 import { Section } from '../../../types/Section';
 import GridWrapper from '../../GridWrapper';
 import Heading from '../../Heading';
@@ -7,7 +8,7 @@ import TextBlock from '../TextBlock';
 import styles from './TextAndImage.module.css';
 
 type TextAndImageProps = {
-  image: any;
+  image: Figure;
   text: Section[];
   tagline?: string;
   title?: string;
@@ -23,7 +24,7 @@ export const TextAndImage = ({
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
             src={imageUrlFor(image).ignoreImageParams().url()}
-            alt=""
+            alt={image.alt}
             className={styles.image}
           />
         </div>


### PR DESCRIPTION
# TextAndImage.tsx: render Figure's alt text if present

## Intent

Fixes [this](https://app.shortcut.com/sanity-io/story/15878/sponsorship-image-alt-text-not-displayed) Shortcut Story.

## Testing this PR

Inspect the "30% Content Strategists ..." image at [/sponsorship-information](https://structured-content-2022-web-cugds69ih.sanity.build/sponsorship-information) and verify that the HTML tag contains an `alt` attribute with the content `30% Content Strategists. 30%  Engineers. 40% Technology Executives.`