### PR TITLE
Black links

### DIFF
--- a/web/styles/globals.css
+++ b/web/styles/globals.css
@@ -64,7 +64,7 @@ ul {
 }
 
 a {
-  color: var(--color-sanity-blue);
+  color: var(--color-brand-black);
   text-decoration: underline;
 }
 


### PR DESCRIPTION
# Change default link color to black

## Intent

Change color of regular links from blue to black, as per [Shortcut](https://app.shortcut.com/sanity-io/story/15889/all-links-to-have-black-fonts-instead-of-blue)

## Description

Resolves an issue of too low contrast for links in the column headers of the pricing table.

I've interpreted the Shortcut card literally, so these links will be black unlike the rest of this text which is some shade of gray.

## Testing this PR
1. Open the [/program](https://structured-content-2022-web-git-black-links.sanity.build/program) page
2. Scroll down to "Program schedules" and verify that the "workshop" link has black text (but is still underlined)