### PR TITLE
Mobile menu button adjustments

### DIFF
--- a/web/components/Nav/Nav.module.css
+++ b/web/components/Nav/Nav.module.css
@@ -59,7 +59,7 @@
     display: block;
     text-align: center;
     position: fixed;
-    bottom: 46px;
+    bottom: 38px;
     left: 0;
     right: 0;
     z-index: 1;

--- a/web/components/Nav/Nav.module.css
+++ b/web/components/Nav/Nav.module.css
@@ -67,34 +67,27 @@
 
   .menuButton {
     display: inline-block;
-    padding: 18px 24px;
+    padding: 18px 24px 18px 65px;
     border-radius: 6px;
     border: none;
     font: var(--font-body-large-medium);
     letter-spacing: var(--letter-spacing-body-large);
-    background: var(--color-brand-yellow);
-  }
-
-  .menuButton::before {
-    content: url('../../images/menu.svg');
-    line-height: 1;
-    vertical-align: bottom;
-    margin-right: 17px;
+    background-color: var(--color-brand-yellow);
+    background-image: url('../../images/menu.svg');
+    background-repeat: no-repeat;
+    background-position: 24px 22px;
   }
 
   .menuButton.menuOpen {
     align-self: center;
   }
 
-  .menuButton.menuOpen::before {
-    content: url('../../images/close.svg');
-    line-height: 1;
-    vertical-align: bottom;
-    margin-right: 20px;
+  .menuButton.menuOpen {
+    background-image: url('../../images/close.svg');
   }
 
   .menuButton:active {
-    background: var(--color-brand-yellow-light);
+    background-color: var(--color-brand-yellow-light);
   }
 
   .menuContents {

--- a/web/styles/globals.css
+++ b/web/styles/globals.css
@@ -70,6 +70,7 @@ a {
 
 button,
 input {
+  color: var(--color-brand-black);
   font: inherit;
 }
 


### PR DESCRIPTION
# Mobile menu button adjustments

## Intent

Move the mobile menu button a bit further down on the screen, and fix its appearance in iOS Safari, as detailed in [Shortcut](https://app.shortcut.com/sanity-io/story/15826/mobile-menu-button-adjustments)

## Description

Moving the button further down was simply a change to the `bottom` offset.

For the alignment in iOS, I ended up choosing not to bother with debugging the exact reason it would align differently there. (I actually tested it in desktop Safari on BrowserStack, and there it had the exact opposite problem, with the image being aligned further _up_ than the text…) Instead I changed it to use a `background-image`, so positioning can be controlled more precisely. Putting images in generated content works OK as long as you don't need to style them, but you can't set e.g. `vertical-align` on the image itself, so since it didn't work "out of the box" with baseline alignment after all, it seems better to use a different mechanism that provides more control.

I also removed the blue color seen in the screenshot in Shortcut.

## Testing this PR
1. Open the [front page](http://structured-content-2022-web-git-mobile-menu-button-adjustments.sanity.build/) on an iOS device with typical phone dimensions, using something like BrowserStack if necessary (I tested iPhone 13 in BrowserStack)
2. Verify that the "Menu" button is slightly further down than on staging and that the icon (two horizontal lines (burger menu without the patty?)) and text look correctly aligned