### PR TITLE
Fix supported internal links

### DIFF
--- a/web/components/SimpleCallToAction/SimpleCallToAction.tsx
+++ b/web/components/SimpleCallToAction/SimpleCallToAction.tsx
@@ -1,6 +1,6 @@
 import { SimpleCallToAction as SimpleCallToActionProps } from '../../types/SimpleCallToAction';
 import ButtonLink from '../ButtonLink';
-import urlJoin from "proper-url-join";
+import urlJoin from 'proper-url-join';
 
 export const SimpleCallToAction = ({
   text,

--- a/web/components/TextBlock/TextAndImage/TextAndImage.tsx
+++ b/web/components/TextBlock/TextAndImage/TextAndImage.tsx
@@ -1,6 +1,6 @@
 import { PortableTextComponentProps } from '@portabletext/react';
 import { imageUrlFor } from '../../../lib/sanity';
-import { Figure } from "../../../types/Figure";
+import { Figure } from '../../../types/Figure';
 import { Section } from '../../../types/Section';
 import GridWrapper from '../../GridWrapper';
 import Heading from '../../Heading';

--- a/web/pages/article/[slug].tsx
+++ b/web/pages/article/[slug].tsx
@@ -20,7 +20,10 @@ const QUERY = groq`
         ...,
         markDefs[] {
           ...,
-          reference->,
+          reference-> {
+            _type,
+            slug,
+          },
         },
       },
     },

--- a/web/pages/article/[slug].tsx
+++ b/web/pages/article/[slug].tsx
@@ -14,7 +14,16 @@ import MetaTags from '../../components/MetaTags';
 
 const QUERY = groq`
   {
-    "article": *[_type == "article" && slug.current == $slug][0],
+    "article": *[_type == "article" && slug.current == $slug][0] {
+      ...,
+      content[] {
+        ...,
+        markDefs[] {
+          ...,
+          reference->,
+        },
+      },
+    },
     "home": *[_id == "${mainEventId}"][0] {
       "ticketsUrl": microcopy[key == "mainCta"][0].action,
     },

--- a/web/util/entityPaths.ts
+++ b/web/util/entityPaths.ts
@@ -1,8 +1,9 @@
 import urlJoin from 'proper-url-join';
+import { Slug } from '../types/Slug';
 
 export const mainEventId = 'aad77280-6394-4090-afad-1c0f2a0416c6';
 
-export const getEntityPath = (entity?: any) => {
+export const getEntityPath = (entity?: { _type: string; slug: Slug }) => {
   if (!entity?.slug?.current) {
     return '#';
   }
@@ -13,7 +14,9 @@ export const getEntityPath = (entity?: any) => {
     case 'article':
       return urlJoin('article', entity.slug.current, { leadingSlash: true });
     default:
-      console.error(`getEntityPath: unsupported entity type: '${entity._type}'`);
+      console.error(
+        `getEntityPath: unsupported entity type: '${entity._type}'`
+      );
       return '#';
   }
 };

--- a/web/util/entityPaths.ts
+++ b/web/util/entityPaths.ts
@@ -1,23 +1,19 @@
 import urlJoin from 'proper-url-join';
-import { Session } from '../types/Session';
-import { Venue } from '../types/Venue';
-import { Person } from '../types/Person';
-
-type Entity = Person | Session | Venue;
 
 export const mainEventId = 'aad77280-6394-4090-afad-1c0f2a0416c6';
 
-export const getEntityPath = (entity?: Entity) => {
+export const getEntityPath = (entity?: any) => {
   if (!entity?.slug?.current) {
     return '#';
   }
 
   switch (entity._type) {
-    case 'session':
-    case 'person':
-    case 'venue':
-      return urlJoin(`${entity._type}s`, entity.slug?.current);
+    case 'route':
+      return urlJoin(entity.slug.current, { leadingSlash: true });
+    case 'article':
+      return urlJoin('article', entity.slug.current, { leadingSlash: true });
     default:
-      return '';
+      console.error(`getEntityPath: unsupported entity type: '${entity._type}'`);
+      return '#';
   }
 };


### PR DESCRIPTION
# Fix supported internal links

## Intent

- Support only `route` and `article` `internalLink` types; fix `getEntityPath` URL resolution for those two entity types
- Fetch `markDefs` references for articles, which fixes internal links in _/article/:slug_

## Description

I've confirmed with Celine that `route` and `article` are the only two entities we support for `internalLink`. It then makes sense to me to link to articles using the `/article/:slug` path. This is not an editor-only route, I don't know where I got that from. From the related [Story](https://app.shortcut.com/sanity-io/story/15481/routing-update-to-handle-editorial-articles), my impression from @kmelve's wording is that the `/article/:slug` -> `/:slug` rewriting we do is an "extra" and that the "canonical" URL which we should link to is the former. This also matches with the `canonical` attribute we set for article URLs, both rewritten and not.


## Testing this PR

I've created an [Editorial Article](https://stagingadmin.structuredcontent.live/desk/article;72149d3a-1f8c-4be6-822c-ef313370c03d%2Ctemplate%3Darticle) which is available at [/article/test](https://structured-content-2022-web-qvs1gafr3.sanity.build/article/test). Verify that the links on the page point to expected targets. 
