### PR TITLE
Update cookie banner styling

### DIFF
--- a/web/components/CookieConsent/CookieConsent.module.css
+++ b/web/components/CookieConsent/CookieConsent.module.css
@@ -1,23 +1,23 @@
 .container {
   position: fixed;
   bottom: 16px;
-  left: 16px;
-  right: 16px;
-  background-color: var(--color-brand-yellow-light);
+  left: 0;
+  right: 0;
+  max-width: var(--grid-width);
+  padding: 0 var(--grid-half-gutter);
+  margin: 0 auto;
   font: var(--font-body-small-medium);
   letter-spacing: var(--letter-spacing-body-small);
-  border-radius: 8px;
-  box-shadow: 0 6px 0 rgba(0, 0, 0, 0.1);
 }
 
 .consentContainer {
   padding: 24px;
   display: flex;
   flex-direction: column;
-  max-width: calc(var(--grid-width) - 2 * var(--grid-gutter));
-  box-sizing: content-box;
-  margin-left: auto;
-  margin-right: auto;
+  width: 100%;
+  background-color: var(--color-brand-yellow-light);
+  border-radius: 8px;
+  box-shadow: 0 6px 0 rgba(0, 0, 0, 0.1);
 }
 
 .link {
@@ -64,6 +64,10 @@
 }
 
 @media (--medium-up) {
+  .container {
+    padding: 0 var(--grid-medium-gutter);
+  }
+
   .consentContainer {
     justify-content: space-between;
     align-items: center;
@@ -89,6 +93,7 @@
 
 @media (--large-up) {
   .container {
+    padding: 0 var(--grid-gutter);
     border-radius: 12px;
   }
 }

--- a/web/components/CookieConsent/CookieConsent.module.css
+++ b/web/components/CookieConsent/CookieConsent.module.css
@@ -6,7 +6,7 @@
   background-color: var(--color-brand-yellow-light);
   font: var(--font-body-small-medium);
   letter-spacing: var(--letter-spacing-body-small);
-  border-radius: 6px;
+  border-radius: 8px;
 }
 
 .consentContainer {
@@ -83,5 +83,11 @@
     padding-left: 1.5rem;
     padding-right: 1.5rem;
     flex: 1 1 auto;
+  }
+}
+
+@media (--large-up) {
+  .container {
+    border-radius: 12px;
   }
 }

--- a/web/components/CookieConsent/CookieConsent.module.css
+++ b/web/components/CookieConsent/CookieConsent.module.css
@@ -4,11 +4,10 @@
   left: 0;
   right: 0;
   width: 100%;
-  background-color: rgb(19, 25, 34);
+  background-color: var(--color-brand-yellow-light);
 }
 
 .consentContainer {
-  color: rgb(175, 186, 202);
   padding: 1rem;
   display: flex;
   flex-direction: column;
@@ -52,15 +51,19 @@
 .consentButton {
   color: rgb(62, 30, 37);
   padding: 0.5rem 1rem;
-  background-color: rgb(243, 100, 88);
-  border: 1px solid rgb(243, 100, 88);
+  background-color: var(--color-brand-orange);
+  border: 1px solid var(--color-brand-orange);
   cursor: pointer;
   margin-left: 1rem;
   flex: 1 1 0;
 }
 
 .consentButton:hover {
-  background-color: rgb(246 139 130);
+  background-color: var(--color-brand-yellow);
+}
+
+.consentButton:active {
+  background-color: var(--color-brand-yellow-light);
 }
 
 @media (min-width: 768px) {
@@ -73,7 +76,7 @@
 
 .declineButton {
   padding: 0.5rem 1rem;
-  border: 1px solid rgb(60, 71, 88);
+  border: 1px solid black;
   flex: 1 1 0;
   cursor: pointer;
   background: transparent;
@@ -82,7 +85,7 @@
 }
 
 .declineButton:hover {
-  background-color: rgb(28 36 48);
+  background-color: var(--color-brand-yellow);
 }
 
 @media (min-width: 768px) {
@@ -92,15 +95,6 @@
 }
 
 .link {
-  color: rgb(243, 100, 88);
   white-space: nowrap;
   text-decoration: inherit;
-}
-
-.link:focus-visible {
-  outline: auto;
-}
-
-.link:hover {
-  color: rgb(246, 139, 130);
 }

--- a/web/components/CookieConsent/CookieConsent.module.css
+++ b/web/components/CookieConsent/CookieConsent.module.css
@@ -24,6 +24,11 @@
   white-space: nowrap;
 }
 
+.link::after {
+  content: ' ->';
+  letter-spacing: normal; /* to enable -> ligature in Chrome */
+}
+
 .buttonWrapper {
   display: flex;
   margin-top: 1rem;

--- a/web/components/CookieConsent/CookieConsent.module.css
+++ b/web/components/CookieConsent/CookieConsent.module.css
@@ -6,6 +6,7 @@
   background-color: var(--color-brand-yellow-light);
   font: var(--font-body-small-medium);
   letter-spacing: var(--letter-spacing-body-small);
+  border-radius: 6px;
 }
 
 .consentContainer {

--- a/web/components/CookieConsent/CookieConsent.module.css
+++ b/web/components/CookieConsent/CookieConsent.module.css
@@ -7,6 +7,7 @@
   font: var(--font-body-small-medium);
   letter-spacing: var(--letter-spacing-body-small);
   border-radius: 8px;
+  box-shadow: 0 6px 0 rgba(0, 0, 0, 0.1);
 }
 
 .consentContainer {

--- a/web/components/CookieConsent/CookieConsent.module.css
+++ b/web/components/CookieConsent/CookieConsent.module.css
@@ -53,7 +53,7 @@
   color: rgb(62, 30, 37);
   padding: 0.5rem 1rem;
   background-color: var(--color-brand-orange);
-  border: 1px solid var(--color-brand-orange);
+  border: none;
   border-radius: 6px;
   cursor: pointer;
   margin-left: 1rem;

--- a/web/components/CookieConsent/CookieConsent.module.css
+++ b/web/components/CookieConsent/CookieConsent.module.css
@@ -1,40 +1,25 @@
 .container {
   position: fixed;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  width: 100%;
+  bottom: 16px;
+  left: 16px;
+  right: 16px;
   background-color: var(--color-brand-yellow-light);
+  font: var(--font-body-small-medium);
+  letter-spacing: var(--letter-spacing-body-small);
 }
 
 .consentContainer {
-  padding: 1rem;
+  padding: 24px;
   display: flex;
   flex-direction: column;
-  max-width: 52rem;
+  max-width: calc(var(--grid-width) - 2 * var(--grid-gutter));
+  box-sizing: content-box;
   margin-left: auto;
   margin-right: auto;
 }
 
-@media (min-width: 768px) {
-  .consentContainer {
-    justify-content: space-between;
-    align-items: center;
-    flex-direction: row;
-  }
-}
-
-@media (min-width: 1024px) {
-  .consentContainer {
-    padding-left: 0;
-    padding-right: 0;
-  }
-}
-
-@media (min-width: 768px) {
-  .consentContent {
-    max-width: 28rem;
-  }
+.link {
+  white-space: nowrap;
 }
 
 .buttonWrapper {
@@ -42,10 +27,19 @@
   margin-top: 1rem;
 }
 
-@media (min-width: 768px) {
-  .buttonWrapper {
-    margin-top: 0;
-  }
+.declineButton {
+  padding: 0.5rem 1rem;
+  border: 1px solid black;
+  border-radius: 6px;
+  flex: 1 1 auto;
+  cursor: pointer;
+  background: transparent;
+  color: inherit;
+  font-size: 100%;
+}
+
+.declineButton:hover {
+  background-color: var(--color-brand-yellow);
 }
 
 .consentButton {
@@ -53,6 +47,7 @@
   padding: 0.5rem 1rem;
   background-color: var(--color-brand-orange);
   border: 1px solid var(--color-brand-orange);
+  border-radius: 6px;
   cursor: pointer;
   margin-left: 1rem;
   flex: 1 1 0;
@@ -66,35 +61,26 @@
   background-color: var(--color-brand-yellow-light);
 }
 
-@media (min-width: 768px) {
+@media (--medium-up) {
+  .consentContainer {
+    justify-content: space-between;
+    align-items: center;
+    flex-direction: row;
+  }
+
+  .consentContent {
+    max-width: var(--max-body-text-width);
+    margin-right: 24px;
+  }
+
+  .buttonWrapper {
+    margin-top: 0;
+    flex: none;
+  }
+
   .consentButton {
     padding-left: 1.5rem;
     padding-right: 1.5rem;
     flex: 1 1 auto;
   }
-}
-
-.declineButton {
-  padding: 0.5rem 1rem;
-  border: 1px solid black;
-  flex: 1 1 0;
-  cursor: pointer;
-  background: transparent;
-  color: inherit;
-  font-size: 100%;
-}
-
-.declineButton:hover {
-  background-color: var(--color-brand-yellow);
-}
-
-@media (min-width: 768px) {
-  .declineButton {
-    flex: 1 1 auto;
-  }
-}
-
-.link {
-  white-space: nowrap;
-  text-decoration: inherit;
 }

--- a/web/components/CookieConsent/CookieConsent.tsx
+++ b/web/components/CookieConsent/CookieConsent.tsx
@@ -22,7 +22,7 @@ export const CookieConsent = () => (
         target="_blank"
         rel="noreferrer"
       >
-        Learn more →
+        Learn more
       </a>
     </ReactCookieConsent>
   </div>


### PR DESCRIPTION
# Update cookie banner styling

## Intent

Update the cookie banner with new design including brand colors, as per Figma sketch. See also [Shortcut](https://app.shortcut.com/sanity-io/story/15672/update-cookie-banner-with-brand-colors) story.

## Description

I've kept some of the existing style declarations (originally for deadline reasons), they seem to be good enough. Also the Figma sketch is not complete for mobile/tablet/desktop anyway.

Reorganized the declaration blocks a bit since I find them easier to work with that way (e.g. in terms of consistency with other .module.css files). Basically the order is roughly the same as the order of the corresponding elements in the DOM, and media queries are at the end, smallest to largest.

Also, the arrow has been removed from the content and added to the CSS, since I would consider it a stylistic thing. This mirrors e.g. `ButtonLink`.

## Testing this PR
1. Open https://structured-content-2022-web-git-update-cookie-banner-styling.sanity.build/
2. Verify that the cookie banner looks OK and has the appropriate colors for text/buttons/background