### PR TITLE
Q&A section: render `title` heading

### DIFF
--- a/web/components/SimpleCallToAction/SimpleCallToAction.tsx
+++ b/web/components/SimpleCallToAction/SimpleCallToAction.tsx
@@ -1,6 +1,6 @@
 import { SimpleCallToAction as SimpleCallToActionProps } from '../../types/SimpleCallToAction';
 import ButtonLink from '../ButtonLink';
-import urlJoin from "proper-url-join";
+import urlJoin from 'proper-url-join';
 
 export const SimpleCallToAction = ({
   text,

--- a/web/components/TextBlock/QuestionAndAnswerCollection/QuestionAndAnswerCollection.module.css
+++ b/web/components/TextBlock/QuestionAndAnswerCollection/QuestionAndAnswerCollection.module.css
@@ -2,6 +2,10 @@
   margin: 80px 0;
 }
 
+.title {
+  margin-bottom: 40px;
+}
+
 .section {
   margin: 8px 0;
   background: var(--color-brand-yellow-light);
@@ -20,12 +24,20 @@
     margin: 96px 0;
   }
 
+  .title,
   .section {
-    padding: 64px 52px;
     box-sizing: content-box;
     max-width: var(--max-body-text-width);
     margin-left: auto;
     margin-right: auto;
+  }
+
+  .title {
+    margin-bottom: 48px;
+  }
+
+  .section {
+    padding: 64px 52px;
   }
 
   .answer {
@@ -40,6 +52,10 @@
     margin: 128px 0;
     grid-template-columns: repeat(12, minmax(0, 1fr));
     column-gap: var(--grid-gutter);
+  }
+
+  .title {
+    margin-bottom: 64px;
   }
 
   .section {

--- a/web/components/TextBlock/QuestionAndAnswerCollection/QuestionAndAnswerCollection.tsx
+++ b/web/components/TextBlock/QuestionAndAnswerCollection/QuestionAndAnswerCollection.tsx
@@ -3,9 +3,16 @@ import GridWrapper from '../../GridWrapper';
 import TextBlock from '../TextBlock';
 import styles from './QuestionAndAnswerCollection.module.css';
 
-export const QuestionAndAnswerCollection = ({ value: { questions } }) => (
+export const QuestionAndAnswerCollection = ({
+  value: { questions, title, _key },
+}) => (
   <GridWrapper>
     <div className={styles.container}>
+      {title && (
+        <h2 id={`heading-h2-${_key}`} className={styles.title}>
+          {title}
+        </h2>
+      )}
       {questions.map(({ _key, question, answer }) => (
         <section key={_key} className={styles.section}>
           <Heading type="h3">{question}</Heading>

--- a/web/components/TextBlock/TextAndImage/TextAndImage.tsx
+++ b/web/components/TextBlock/TextAndImage/TextAndImage.tsx
@@ -1,6 +1,6 @@
 import { PortableTextComponentProps } from '@portabletext/react';
 import { imageUrlFor } from '../../../lib/sanity';
-import { Figure } from "../../../types/Figure";
+import { Figure } from '../../../types/Figure';
 import { Section } from '../../../types/Section';
 import GridWrapper from '../../GridWrapper';
 import Heading from '../../Heading';


### PR DESCRIPTION
# Q&A section: render `title` heading

## Intent

Renders `title` field for `QuestionAndAnswerCollection` section, if present.
Fixes [this](https://app.shortcut.com/sanity-io/story/15929/render-heading-in-the-q-a-section) Shortcut Story.

## Testing this PR

1. Go to [/registration-info](https://structured-content-2022-web-c1fmzynlx.sanity.build/registration-info)
2. Scroll down to the "Registration Details" heading and verify that it renders in accordance with the Story specifications
3. (Push any CSS-related fixes directly to this branch)