### PR TITLE
Fix footer email

### DIFF
--- a/web/components/Footer/Footer.tsx
+++ b/web/components/Footer/Footer.tsx
@@ -28,8 +28,8 @@ export const Footer = ({ links }: FooterProps) => (
 
       <Paragraph>
         Inquiries:
-        <a className={styles.mailLink} href="mailto:email@sanity.io">
-          email@sanity.io
+        <a className={styles.mailLink} href="mailto:confinfo@sanity.io">
+          confinfo@sanity.io
         </a>
       </Paragraph>
 


### PR DESCRIPTION
# Fix footer email

## Intent

Update to correct email address for the "Inquiries" link in the footer, as described in [Slack](https://wja.slack.com/archives/C02E2ERKR7E/p1646674449117139)

## Description

Simple string replacement

## Testing this PR
1. Open https://structured-content-2022-web-git-fix-footer-email.sanity.build/
2. Scroll down to the bottom
3. Verify that email address for "Inquiries" is `confinfo@sanity.io`, both in the link text and in the `mailto:` URL it refers to