### PR TITLE
Mac font smoothing workaround

### DIFF
--- a/web/styles/globals.css
+++ b/web/styles/globals.css
@@ -31,6 +31,13 @@ body {
   margin: 0;
   font: var(--font-body-base);
   letter-spacing: var(--letter-spacing-body-base);
+  /* Intentionally using only the non-standard prefixed properties, because
+   * this is a workaround for a Mac-only issue. Requested by designer
+   * (globally, not just for light-on-dark special cases, of which we currently
+   * have none).
+   */
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
 body.main-menu-open {


### PR DESCRIPTION
# Mac font smoothing workaround

## Intent

This is a change requested by Sindre in https://app.shortcut.com/sanity-io/story/16013/minor-design-implementation-tweaks (see first task). Apparently the text looks bolder/blacker in macOS because of subpixel antialiasing (don't know of there is a difference between "retina" screens and lower-res ones), and these proprietary CSS properties make it look more like intended.

## Description

See also discussion in [Slack](https://wja.slack.com/archives/C02E2ERKR7E/p1646829184454019) (URL from Minus' Slack workspace, visitors from Behalf/Sanity may need to replace the host name because of how Slack Connections work)

## Testing this PR

1. If you have access to a macOS machine, either physically or via BrowserStack: Open https://structured-content-2022-web-git-mac-font-smoothing-workaround.sanity.build/ and verify that the text "Join us […]" intro looks pretty similar to the [Figma sketch](https://www.figma.com/file/XjAvJKsLpxYJSc8QDWK81j/Sanity-SCC-Website-(Shared)?node-id=0%3A1) w.r.t. how "black"/bold the text looks
2. Verify that it at least doesn't look worse on your own system, if it's a non-macOS thing (I think it's expected to show 0 difference since these properties only have an effect on Mac)