### PR TITLE
SSG for Editorial Articles

### DIFF
--- a/web/pages/api/revalidate.ts
+++ b/web/pages/api/revalidate.ts
@@ -9,6 +9,7 @@ const SECTION_UPDATED_QUERY = `
   }["slug"][]`;
 const PAGE_UPDATED_QUERY = `*[_type == "route" && references($id)].slug.current`;
 const ROUTE_UPDATED_QUERY = `*[_type == "route" && _id == $id].slug.current`;
+const ARTICLE_UPDATED_QUERY = `*[_type == "article" && _id == $id].slug.current`;
 
 const getQueryForType = (type: string) => {
   switch (type) {
@@ -16,6 +17,8 @@ const getQueryForType = (type: string) => {
       return ROUTE_UPDATED_QUERY;
     case 'page':
       return PAGE_UPDATED_QUERY;
+    case 'article':
+      return ARTICLE_UPDATED_QUERY;
     default:
       return SECTION_UPDATED_QUERY;
   }
@@ -51,7 +54,10 @@ export default async function revalidate(
 
   try {
     await Promise.all(
-      relatedRoutes.map((route) => res.unstable_revalidate(urlJoin(route)))
+      relatedRoutes.map((route) => {
+        const path = urlJoin(_type === 'article' ? 'article' : '', route);
+        return res.unstable_revalidate(path);
+      })
     );
     const updatedRoutes = `Updated routes: ${relatedRoutes.join(', ')}`;
     log(updatedRoutes);


### PR DESCRIPTION
# SSG for Editorial Articles

## Intent

A continuation of #105, using the same approach for Editorial Articles on _/article/:slug_.

## Description

Not much is different here from #105. I've added an extra `.filter(({ params: { slug } }) => Boolean(slug));` to `getStaticPaths` because accessing _/article/_ without a slug is not supposed to be a valid route. Otherwise I've kept the code much the same as for _[[...slug]].tsx_.

## Testing this PR

I've set up a new [webhook](https://www.sanity.io/organizations/oSyH1iET5/project/33zsuc7i/api) for testing purposes. It should be configured exactly the same as the webhook for production, except that it points to [this branch's Preview Deployment](https://structured-content-2022-web-git-article-ssg.sanity.build) instead.

1. Open the [Realtime Logs](https://vercel.com/sanity-io/structured-content-2022-web/BvQE1hd72AhtuZztvzHrNfXbjp6x/functions?name=api%2Frevalidate) for the latest commit of this PR and filter on the _api/preview_ Function
2. Open the [Test article](https://structured-content-2022-web-git-article-ssg.sanity.build/article/test) on this branch's Preview Deploy
3. Make a change in the [Test article](https://stagingadmin.structuredcontent.live/desk/article;72149d3a-1f8c-4be6-822c-ef313370c03d) and publish it
4. Verify that a request is logged in the Realtime Logs, and that refreshing the Test article renders the change you made