### PR TITLE
Random shapes in NavBlock

### DIFF
--- a/web/components/NavBlock/NavBlock.tsx
+++ b/web/components/NavBlock/NavBlock.tsx
@@ -1,33 +1,44 @@
 import Link from 'next/link';
 import clsx from 'clsx';
 import styles from './NavBlock.module.css';
+import { useEffect, useState } from 'react';
+
+const RANDOM_SHAPE_PERCENT_CHANCE = 0.33;
+type Shape = 'Plus' | 'C' | 'Ovals' | 'O' | 'HalfOval';
 
 interface FakeItemProps {
   divider?: boolean;
   mobile?: boolean;
   tablet?: boolean;
   desktop?: boolean;
-  shape?: 'Plus' | 'C' | 'Ovals' | 'O' | 'HalfOval';
 }
 
-const FakeItem = ({
-  divider,
-  mobile,
-  tablet,
-  desktop,
-  shape,
-}: FakeItemProps) => (
-  <li
-    className={clsx(
-      divider ? styles.divider : styles.fakeItem,
-      mobile && styles.mobile,
-      tablet && styles.tablet,
-      desktop && styles.desktop,
-      shape && styles[`shape${shape}`]
-    )}
-    aria-hidden="true"
-  />
-);
+const getRandomShape = (): Shape => {
+  const shapes: Shape[] = ['Plus', 'C', 'Ovals', 'O', 'HalfOval'];
+  return shapes[Math.floor(Math.random() * shapes.length)];
+};
+
+const FakeItem = ({ divider, mobile, tablet, desktop }: FakeItemProps) => {
+  const [shape, setShape] = useState<string>(null);
+  useEffect(() => {
+    if (Math.random() <= RANDOM_SHAPE_PERCENT_CHANCE) {
+      setShape(styles[`shape${getRandomShape()}`]);
+    }
+  }, []);
+
+  return (
+    <li
+      className={clsx(
+        divider ? styles.divider : styles.fakeItem,
+        mobile && styles.mobile,
+        tablet && styles.tablet,
+        desktop && styles.desktop,
+        shape
+      )}
+      aria-hidden="true"
+    />
+  );
+};
 
 interface NavBlockProps {
   ticketsUrl: string;
@@ -43,7 +54,7 @@ export const NavBlock = ({ ticketsUrl }: NavBlockProps) => (
       </li>
 
       <FakeItem mobile tablet desktop />
-      <FakeItem mobile tablet desktop shape="Plus" />
+      <FakeItem mobile tablet desktop />
       <FakeItem divider mobile />
       <FakeItem mobile />
 
@@ -56,9 +67,9 @@ export const NavBlock = ({ ticketsUrl }: NavBlockProps) => (
       <FakeItem tablet desktop />
       <FakeItem divider mobile tablet desktop />
       <FakeItem tablet desktop />
-      <FakeItem tablet desktop shape="C" />
       <FakeItem tablet desktop />
-      <FakeItem mobile tablet desktop shape="Ovals" />
+      <FakeItem tablet desktop />
+      <FakeItem mobile tablet desktop />
 
       <li className={styles.item}>
         <Link href="/registration-info">
@@ -74,10 +85,10 @@ export const NavBlock = ({ ticketsUrl }: NavBlockProps) => (
         </Link>
       </li>
 
-      <FakeItem mobile shape="HalfOval" />
+      <FakeItem mobile />
       <FakeItem mobile tablet desktop />
       <FakeItem divider mobile />
-      <FakeItem desktop shape="O" />
+      <FakeItem desktop />
 
       <li className={styles.item}>
         <Link href={ticketsUrl}>
@@ -85,7 +96,7 @@ export const NavBlock = ({ ticketsUrl }: NavBlockProps) => (
         </Link>
       </li>
 
-      <FakeItem tablet desktop shape="HalfOval" />
+      <FakeItem tablet desktop />
       <FakeItem mobile desktop />
     </ul>
   </nav>

--- a/web/components/NavBlock/NavBlock.tsx
+++ b/web/components/NavBlock/NavBlock.tsx
@@ -19,10 +19,10 @@ const getRandomShape = (): Shape => {
 };
 
 const FakeItem = ({ divider, mobile, tablet, desktop }: FakeItemProps) => {
-  const [shape, setShape] = useState<string>(null);
+  const [shapeClass, setShapeClass] = useState<string>(null);
   useEffect(() => {
     if (Math.random() <= RANDOM_SHAPE_PERCENT_CHANCE) {
-      setShape(styles[`shape${getRandomShape()}`]);
+      setShapeClass(styles[`shape${getRandomShape()}`]);
     }
   }, []);
 
@@ -33,7 +33,7 @@ const FakeItem = ({ divider, mobile, tablet, desktop }: FakeItemProps) => {
         mobile && styles.mobile,
         tablet && styles.tablet,
         desktop && styles.desktop,
-        shape
+        shapeClass
       )}
       aria-hidden="true"
     />

--- a/web/components/NavBlock/NavBlock.tsx
+++ b/web/components/NavBlock/NavBlock.tsx
@@ -85,10 +85,9 @@ export const NavBlock = ({ ticketsUrl }: NavBlockProps) => (
         </Link>
       </li>
 
-      <FakeItem mobile />
       <FakeItem mobile tablet desktop />
+      <FakeItem mobile desktop />
       <FakeItem divider mobile />
-      <FakeItem desktop />
 
       <li className={styles.item}>
         <Link href={ticketsUrl}>


### PR DESCRIPTION
# Random shapes in NavBlock

## Intent

Replaces hard-coded shapes in NavBlock with all `FakeItem`s having 33% chance to be a random shape.
Fixes part 1 of [this Shortcut Story](https://app.shortcut.com/sanity-io/story/16075/animate-nav-block).

## Description

(I also took a shot at animating the NavBlock using [react-awesome-reveal](https://github.com/morellodev/react-awesome-reveal), but the library wraps its child elements in `div`s and `span`s, and also seems to not apply the `childClassName` prop to its children. I need to consider other approaches here, and am postponing the implementation to a separate PR so that this simpler code can be shipped.)

The `useEffect` in `FakeItem` is only executed client-side, so this approach avoids the "CSS class names on client and server did not match" error.

## Testing this PR

Visit the [frontpage](https://structured-content-2022-web-bm6g9swt3.sanity.build/) of the Preview Deploy for this PR, and refresh a couple times. Verify that the NavBlock shapes change, and that no errors or warnings are logged to the console.