### PR TITLE
Minor design tweaks

### DIFF
--- a/web/components/ConferenceUpdatesForm/ConferenceUpdatesForm.module.css
+++ b/web/components/ConferenceUpdatesForm/ConferenceUpdatesForm.module.css
@@ -24,6 +24,7 @@
   /* Design sketch has left padding 24px but then the placeholder won't fit */
   padding: 19.5px 56px 19.5px 10px;
   width: 100%;
+  border-radius: 8px;
 }
 
 .submitButton {

--- a/web/components/ConferenceUpdatesForm/ConferenceUpdatesForm.module.css
+++ b/web/components/ConferenceUpdatesForm/ConferenceUpdatesForm.module.css
@@ -3,6 +3,7 @@
   padding: 48px 24px;
   background: var(--color-brand-yellow-light);
   margin: 80px 0;
+  border-radius: 12px;
 }
 
 .image {

--- a/web/components/Footer/Footer.module.css
+++ b/web/components/Footer/Footer.module.css
@@ -11,7 +11,6 @@
 }
 
 .mailLink {
-  display: block;
   text-decoration: none;
   color: var(--color-ui-gray-600);
 }

--- a/web/components/Footer/Footer.module.css
+++ b/web/components/Footer/Footer.module.css
@@ -10,6 +10,10 @@
   margin-bottom: 20px;
 }
 
+.logoLink {
+  display: inline-block; /* nicer focus outline */
+}
+
 .mailLink {
   text-decoration: none;
   color: var(--color-ui-gray-600);

--- a/web/components/Footer/Footer.tsx
+++ b/web/components/Footer/Footer.tsx
@@ -27,7 +27,6 @@ export const Footer = ({ links }: FooterProps) => (
       <Paragraph>Structured Content 2022 is a conference by Sanity</Paragraph>
 
       <Paragraph>
-        Inquiries:
         <a className={styles.mailLink} href="mailto:confinfo@sanity.io">
           confinfo@sanity.io
         </a>

--- a/web/components/Footer/Footer.tsx
+++ b/web/components/Footer/Footer.tsx
@@ -5,7 +5,6 @@ import instagramLogo from '../../images/instagram_logo_black.svg';
 import twitterLogo from '../../images/twitter_logo_black.svg';
 import linkedinLogo from '../../images/linkedin_logo_black.svg';
 import GridWrapper from '../GridWrapper';
-import Paragraph from '../Paragraph';
 import styles from './Footer.module.css';
 import { Slug } from '../../types/Slug';
 
@@ -24,13 +23,13 @@ export const Footer = ({ links }: FooterProps) => (
         <Image src={sanityLogo} alt="Sanity" width={139} height={28} />
       </div>
 
-      <Paragraph>Structured Content 2022 is a conference by Sanity</Paragraph>
+      <p>Structured Content 2022 is a conference by Sanity</p>
 
-      <Paragraph>
+      <p>
         <a className={styles.mailLink} href="mailto:confinfo@sanity.io">
           confinfo@sanity.io
         </a>
-      </Paragraph>
+      </p>
 
       <ul className={styles.social}>
         <li className={styles.socialItem}>

--- a/web/components/Footer/Footer.tsx
+++ b/web/components/Footer/Footer.tsx
@@ -25,11 +25,11 @@ export const Footer = ({ links }: FooterProps) => (
 
       <p>Structured Content 2022 is a conference by Sanity</p>
 
-      <p>
+      <address>
         <a className={styles.mailLink} href="mailto:confinfo@sanity.io">
           confinfo@sanity.io
         </a>
-      </p>
+      </address>
 
       <ul className={styles.social}>
         <li className={styles.socialItem}>

--- a/web/components/Footer/Footer.tsx
+++ b/web/components/Footer/Footer.tsx
@@ -20,7 +20,14 @@ export const Footer = ({ links }: FooterProps) => (
   <footer className={styles.container}>
     <GridWrapper>
       <div className={styles.logoContainer}>
-        <Image src={sanityLogo} alt="Sanity" width={139} height={28} />
+        <a
+          href="https://sanity.io/"
+          className={styles.logoLink}
+          target="_blank"
+          rel="noreferrer"
+        >
+          <Image src={sanityLogo} alt="Sanity" width={139} height={28} />
+        </a>
       </div>
 
       <p>Structured Content 2022 is a conference by Sanity</p>

--- a/web/components/Paragraph/Paragraph.module.css
+++ b/web/components/Paragraph/Paragraph.module.css
@@ -1,3 +1,0 @@
-.paragraph {
-  margin-bottom: 1em;
-}

--- a/web/components/Paragraph/Paragraph.tsx
+++ b/web/components/Paragraph/Paragraph.tsx
@@ -1,9 +1,0 @@
-import { HTMLAttributes } from 'react';
-import clsx from 'clsx';
-import styles from './Paragraph.module.css';
-
-interface ParagraphProps extends HTMLAttributes<HTMLParagraphElement> {}
-
-export const Paragraph = ({ className, ...props }: ParagraphProps) => (
-  <p {...props} className={clsx(className, styles.paragraph)} />
-);

--- a/web/components/Paragraph/index.ts
+++ b/web/components/Paragraph/index.ts
@@ -1,1 +1,0 @@
-export { Paragraph as default } from './Paragraph';

--- a/web/components/VenueNames/VenueNames.module.css
+++ b/web/components/VenueNames/VenueNames.module.css
@@ -6,7 +6,7 @@
 
 .venue {
   display: inline-block;
-  font: var(--font-display-sm);
+  font: var(--font-display-base);
 }
 
 .link {

--- a/web/styles/globals.css
+++ b/web/styles/globals.css
@@ -65,6 +65,11 @@ ol {
   margin: 0 0 1em;
 }
 
+address {
+  margin: 0 0 1em;
+  font: inherit;
+}
+
 ul {
   padding-left: 1.5em;
   list-style-type: disc;


### PR DESCRIPTION
# Minor design tweaks

## Intent

Implement most of the remaining tweaks in Shortcut story "[Minor design implementation tweaks (first round)](https://app.shortcut.com/sanity-io/story/16013/minor-design-implementation-tweaks-first-round)", except the task about opening external links in new tab, which is intended to be done in a separate PR

## Description

I figured I would submit these separately in case there were complications with the "open in new tab" thing. The adjustments included here seem much smaller and more straightforward.

Covers the following tasks:
- Footer: Remove "inquieries:" before presenting the contact email in the footer
- Footer: when clicking the Sanity logo - link to sanity.io
- Mobile: Increase homepage locations font size to 40px
- Add border radius to newsletter module according to sketches
- Add border radius to newsletter module input field according to sketches

Along with the first item, I included an "invisible" markup improvement. Using `address` in some sense "makes up for" the removal of the "Inquiries" text, and with just one more `<Paragraph>` → `<p>` replacement it looks like `<Paragraph>` is now unused. I hope the removal of this component is not controversial.

## Testing this PR

1. Open https://structured-content-2022-web-git-minor-design-tweaks.sanity.build/
2. Scroll down to the bottom and verify that the email address in the footer doesn't have "Inquiries:" above it, and that the "SANITY" logo is a clickable link that leads to sanity.io
3. Scroll up a bit and verify that in the "Get conference updates" section, both the yellow container box and the email address input field have rounded corners
4. Shrink the window width to around 320–400px e.g. by using "Responsive Design Mode" or similar
5. Scroll up to the list of venues i.e. "San Fransisco • Oslo" etc, and verify that its text is somewhat bigger than on structuredcontent.live (specifically, 40px font-size if inspecting it with dev tools)