### PR TITLE
External links in new tab / new link structure

### DIFF
--- a/studio/schemas/arrays/blockContent.ts
+++ b/studio/schemas/arrays/blockContent.ts
@@ -22,6 +22,9 @@ export default {
             { type: "ticket" },
           ],
         },
+        {
+          type: "simpleCallToAction",
+        },
       ],
       marks: {
         decorators: [
@@ -31,50 +34,9 @@ export default {
         ],
         annotations: [
           {
-            name: "internalLink",
-            type: "object",
-            title: "Internal link",
-            icon: DocumentsIcon,
-            fields: [
-              {
-                name: "reference",
-                type: "reference",
-                title: "Reference",
-                to: [
-                  { type: "route" },
-                  { type: "person" },
-                  { type: "session" },
-                  { type: "article" },
-                  // other types you may want to link to
-                ],
-              },
-            ],
-          },
-          {
             name: "link",
-            type: "object",
+            type: "link",
             title: "External link",
-            fields: [
-              {
-                name: "href",
-                type: "url",
-                title: "URL",
-                validation: (Rule) => [
-                  Rule.uri({
-                    allowRelative: false,
-                  }).warning(
-                    "Consider the internal link annotation for relative URLs"
-                  ),
-                  Rule.uri({ scheme: ["https", "mailto", "tel"] }),
-                ],
-              },
-              {
-                title: "Open in new tab",
-                name: "blank",
-                description: "Read https://css-tricks.com/use-target_blank/",
-                type: "boolean",
-              },
-            ],
           },
         ],
       },

--- a/studio/schemas/arrays/simpleBlockContent.ts
+++ b/studio/schemas/arrays/simpleBlockContent.ts
@@ -5,6 +5,14 @@ export default {
   of: [
     {
       type: "block",
+      marks: {
+        annotations: [
+          {
+            name: "link",
+            type: "link",
+          },
+        ],
+      },
     },
     {
       type: "simpleCallToAction",

--- a/studio/schemas/documents/navigation.ts
+++ b/studio/schemas/documents/navigation.ts
@@ -1,0 +1,29 @@
+export default {
+  name: "navigation",
+  title: "Navigation",
+  type: "document",
+  fields: [
+    {
+      name: "internalName",
+      title: "Internal name",
+      type: "string",
+    },
+    {
+      name: "slug",
+      type: "slug",
+      title: "Navigation slug",
+      description: "Used to identify this navigation",
+      validation: (Rule) => Rule.required(),
+    },
+    {
+      name: "items",
+      type: "array",
+      title: "Navigation items",
+      of: [
+        {
+          type: "navigation.item",
+        },
+      ],
+    },
+  ],
+};

--- a/studio/schemas/objects/index.ts
+++ b/studio/schemas/objects/index.ts
@@ -7,3 +7,4 @@ export { default as figure } from "./figure";
 export { default as richText } from "./richText";
 export { default as seo } from "./seo";
 export { default as simpleCallToAction } from "./simpleCallToAction";
+export { default as link } from "./link";

--- a/studio/schemas/objects/link.ts
+++ b/studio/schemas/objects/link.ts
@@ -1,0 +1,53 @@
+const warning = "You need to delete this or the other link value.";
+export default {
+  name: "link",
+  type: "object",
+  title: "Link",
+  fields: [
+    {
+      name: "internal",
+      type: "reference",
+      title: "Internal link",
+      description: "Use this to link to something on this site.",
+      hidden: ({ parent }) => !!parent?.external && !parent.internal,
+      validation: (Rule) =>
+        Rule.custom((value, context) => {
+          return value && context.parent?.external ? warning : true;
+        }),
+      to: [
+        {
+          type: "route",
+        },
+        {
+          type: "article",
+        },
+      ],
+    },
+    {
+      name: "external",
+      type: "url",
+      hidden: ({ parent }) => !!parent?.internal && !parent.external,
+      validation: (Rule) => [
+        Rule.uri({ scheme: ["https", "mailto", "tel"] }),
+        Rule.custom((value, context) => {
+          return value && context.parent?.internal ? warning : true;
+        }),
+      ],
+      title: "External",
+      description:
+        "Use this for links to external domains, email, or telephone numbers.",
+    },
+    {
+      name: "blank",
+      type: "boolean",
+      title: "Open in new tab or window",
+      validation: (Rule) =>
+        Rule.custom((value, context) => {
+          return value && context.parent?.internal ? "" : true;
+        }).warning(
+          "Are you sure you want to open this internal link in a new tab or window?"
+        ),
+      description: `Only use this if the user needs to keep the current page persistent (if there is a form etc.). When true, this will lessen the user experience on mobile devices.`,
+    },
+  ],
+};

--- a/studio/schemas/objects/navigationItem.ts
+++ b/studio/schemas/objects/navigationItem.ts
@@ -1,0 +1,18 @@
+export default {
+  name: "navigation.item",
+  type: "object",
+  title: "Navigation item",
+  fields: [
+    {
+      title: "Navigation label",
+      name: "label",
+      type: "string",
+      description: "Overrides the route's title",
+    },
+    {
+      title: "Navigation target",
+      name: "target",
+      type: "link",
+    },
+  ],
+};

--- a/studio/schemas/objects/simpleCallToAction.ts
+++ b/studio/schemas/objects/simpleCallToAction.ts
@@ -12,19 +12,9 @@ export default {
       title: "Text",
     },
     {
-      name: "url",
-      type: "url",
-      title: "Call to Action URL",
-      description: "The target URL.",
-      hidden: ({ parent }) => !parent.url && parent.reference,
-      validation: (Rule) => Rule.uri({ scheme: ["https", "mailto", "tel"] }),
-    },
-    {
-      name: "reference",
-      type: "reference",
-      title: "Reference",
-      hidden: ({ parent }) => !parent.reference && parent.url,
-      to: [{ type: "route" }],
+      name: "link",
+      type: "link",
+      title: "Link",
     },
   ],
 };

--- a/studio/schemas/schema.ts
+++ b/studio/schemas/schema.ts
@@ -15,7 +15,7 @@ import venue from "./documents/venue";
 
 // Objects
 
-import { figure, richText, seo, simpleCallToAction } from "./objects";
+import { figure, richText, seo, simpleCallToAction, link } from "./objects";
 import blockContent from "./arrays/blockContent";
 import questionAndAnswer from "./objects/questionAndAnswer";
 import simpleBlockContent from "./arrays/simpleBlockContent";
@@ -35,6 +35,7 @@ export default createSchema({
     richText,
     seo,
     event,
+    link,
     session,
     person,
     article,

--- a/studio/schemas/schema.ts
+++ b/studio/schemas/schema.ts
@@ -24,6 +24,8 @@ import * as sections from "./sections";
 
 import spec from "./documents/spec";
 import program from "./documents/program";
+import navigation from "./documents/navigation";
+import navigationItem from "./objects/navigationItem";
 
 export default createSchema({
   name: "default",
@@ -38,6 +40,8 @@ export default createSchema({
     link,
     session,
     person,
+    navigation,
+    navigationItem,
     article,
     page,
     route,

--- a/studio/src/deskStructure.ts
+++ b/studio/src/deskStructure.ts
@@ -169,7 +169,8 @@ export default () =>
             })
         ),
       S.documentTypeListItem("sharedSections").title("Shared Sections"),
-      S.listItem()
+      S.documentTypeListItem("navigation").title("Navigation"),
+      /* S.listItem()
         .title("Navigation")
         .icon(MenuIcon)
         .child(
@@ -195,7 +196,7 @@ export default () =>
               }).icon(MenuIcon),
             ])
             .title("Navigation")
-        ),
+        ), */
       S.documentTypeListItem("article").title("Editorial Articles"),
       S.divider(),
       S.documentTypeListItem("ticket").title("Ticket types"),

--- a/studio/src/deskStructure.ts
+++ b/studio/src/deskStructure.ts
@@ -170,33 +170,6 @@ export default () =>
         ),
       S.documentTypeListItem("sharedSections").title("Shared Sections"),
       S.documentTypeListItem("navigation").title("Navigation"),
-      /* S.listItem()
-        .title("Navigation")
-        .icon(MenuIcon)
-        .child(
-          S.list()
-            .items([
-              createDeskHierarchy({
-                title: "Primary Navigation",
-
-                // The hierarchy will be stored in this document ID 👇
-                documentId: "primary-nav",
-
-                // Document types editors should be able to include in the hierarchy
-                referenceTo: ["route"],
-              }).icon(MenuIcon),
-              createDeskHierarchy({
-                title: "Secondary Navigation",
-
-                // The hierarchy will be stored in this document ID 👇
-                documentId: "secondary-nav",
-
-                // Document types editors should be able to include in the hierarchy
-                referenceTo: ["route"],
-              }).icon(MenuIcon),
-            ])
-            .title("Navigation")
-        ), */
       S.documentTypeListItem("article").title("Editorial Articles"),
       S.divider(),
       S.documentTypeListItem("ticket").title("Ticket types"),

--- a/web/components/ButtonLink/ButtonLink.tsx
+++ b/web/components/ButtonLink/ButtonLink.tsx
@@ -4,10 +4,16 @@ import styles from './ButtonLink.module.css';
 interface ButtonLinkProps {
   text: string;
   url: string;
+  openInNewTab?: boolean;
 }
 
-export const ButtonLink = ({ text, url }: ButtonLinkProps) => (
-  <Link href={url}>
-    <a className={styles.button}>{text}</a>
-  </Link>
-);
+export const ButtonLink = ({ text, url, openInNewTab }: ButtonLinkProps) =>
+  openInNewTab ? (
+    <a className={styles.button} href={url} target="_blank" rel="noreferrer">
+      {text}
+    </a>
+  ) : (
+    <Link href={url}>
+      <a className={styles.button}>{text}</a>
+    </Link>
+  );

--- a/web/components/Nav/Nav.tsx
+++ b/web/components/Nav/Nav.tsx
@@ -82,11 +82,15 @@ export const Nav = ({ onFrontPage, currentPath, ticketsUrl }: NavProps) => {
           </Link>
           <ul className={clsx(styles.items, !menuOpened && styles.menuClosed)}>
             <li className={styles.ticketItem}>
-              <Link href={ticketsUrl}>
-                <a className={styles.link} onClick={closeMenu}>
-                  Tickets
-                </a>
-              </Link>
+              <a
+                className={styles.link}
+                href={ticketsUrl}
+                target="_blank"
+                rel="noreferrer"
+                onClick={closeMenu}
+              >
+                Tickets
+              </a>
             </li>
             <BasicMenuItem urlPath="/program" label="Program" />
             <BasicMenuItem
@@ -100,7 +104,7 @@ export const Nav = ({ onFrontPage, currentPath, ticketsUrl }: NavProps) => {
             <BasicMenuItem urlPath="/about" label="About" />
           </ul>
           <div className={styles.ticketButton}>
-            <ButtonLink url={ticketsUrl} text="Tickets" />
+            <ButtonLink url={ticketsUrl} text="Tickets" openInNewTab={true} />
           </div>
         </div>
       </GridWrapper>

--- a/web/components/NavBlock/NavBlock.tsx
+++ b/web/components/NavBlock/NavBlock.tsx
@@ -80,9 +80,14 @@ export const NavBlock = ({ ticketsUrl }: NavBlockProps) => (
       <FakeItem desktop shape="O" />
 
       <li className={styles.item}>
-        <Link href={ticketsUrl}>
-          <a className={styles.link}>Tickets</a>
-        </Link>
+        <a
+          className={styles.link}
+          href={ticketsUrl}
+          target="_blank"
+          rel="noreferrer"
+        >
+          Tickets
+        </a>
       </li>
 
       <FakeItem tablet desktop shape="HalfOval" />

--- a/web/components/SimpleCallToAction/SimpleCallToAction.tsx
+++ b/web/components/SimpleCallToAction/SimpleCallToAction.tsx
@@ -4,13 +4,19 @@ import urlJoin from 'proper-url-join';
 
 export const SimpleCallToAction = ({ text, link }: SimpleCallToActionProps) => {
   const openInNewTab = Boolean(link?.blank);
-  return text && link?.internal?.slug?.current ? (
-    <ButtonLink
-      text={text}
-      url={urlJoin(link.internal.slug.current)}
-      openInNewTab={openInNewTab}
-    />
-  ) : text && link?.external ? (
-    <ButtonLink text={text} url={link.external} openInNewTab={openInNewTab} />
-  ) : null;
+  if (text && link?.internal?.slug?.current) {
+    return (
+      <ButtonLink
+        text={text}
+        url={urlJoin(link.internal.slug.current)}
+        openInNewTab={openInNewTab}
+      />
+    );
+  }
+  if (text && link?.external) {
+    return (
+      <ButtonLink text={text} url={link.external} openInNewTab={openInNewTab} />
+    );
+  }
+  return null;
 };

--- a/web/components/SimpleCallToAction/SimpleCallToAction.tsx
+++ b/web/components/SimpleCallToAction/SimpleCallToAction.tsx
@@ -2,13 +2,15 @@ import { SimpleCallToAction as SimpleCallToActionProps } from '../../types/Simpl
 import ButtonLink from '../ButtonLink';
 import urlJoin from 'proper-url-join';
 
-export const SimpleCallToAction = ({
-  text,
-  url,
-  reference,
-}: SimpleCallToActionProps) =>
-  text && reference?.slug?.current ? (
-    <ButtonLink text={text} url={urlJoin(reference?.slug?.current)} />
-  ) : text && url ? (
-    <ButtonLink text={text} url={url} />
+export const SimpleCallToAction = ({ text, link }: SimpleCallToActionProps) => {
+  const openInNewTab = Boolean(link?.blank);
+  return text && link?.internal?.slug?.current ? (
+    <ButtonLink
+      text={text}
+      url={urlJoin(link.internal.slug.current)}
+      openInNewTab={openInNewTab}
+    />
+  ) : text && link?.external ? (
+    <ButtonLink text={text} url={link.external} openInNewTab={openInNewTab} />
   ) : null;
+};

--- a/web/components/TextBlock/TextBlock/TextBlock.tsx
+++ b/web/components/TextBlock/TextBlock/TextBlock.tsx
@@ -46,14 +46,15 @@ const components: Partial<PortableTextComponents> = {
       <Link href={value?.href || getEntityPath(value.reference)}>{text}</Link>
     ),
     link: ({ children, value }) =>
-      value?.href && (
+      value?.href ? (
         <a
           href={value.href}
-          target={value?.blank && '_blank'}
-          rel={value?.blank && 'noreferrer'}
+          {...(value?.blank ? { target: '_blank', rel: 'noreferrer' } : {})}
         >
           {children}
         </a>
+      ) : (
+        <>{children}</>
       ),
   },
 };

--- a/web/components/TextBlock/TextBlock/TextBlock.tsx
+++ b/web/components/TextBlock/TextBlock/TextBlock.tsx
@@ -45,6 +45,16 @@ const components: Partial<PortableTextComponents> = {
       /* href has been seen in a case where both link and internalLink marks applied */
       <Link href={value?.href || getEntityPath(value.reference)}>{text}</Link>
     ),
+    link: ({ children, value }) =>
+      value?.href && (
+        <a
+          href={value.href}
+          target={value?.blank && '_blank'}
+          rel={value?.blank && 'noreferrer'}
+        >
+          {children}
+        </a>
+      ),
   },
 };
 

--- a/web/components/TextBlock/TextBlock/TextBlock.tsx
+++ b/web/components/TextBlock/TextBlock/TextBlock.tsx
@@ -45,17 +45,25 @@ const components: Partial<PortableTextComponents> = {
       /* href has been seen in a case where both link and internalLink marks applied */
       <Link href={value?.href || getEntityPath(value.reference)}>{text}</Link>
     ),
-    link: ({ children, value }) =>
-      value?.href ? (
+    /* There are two different link marks, but currently TextBlock is used for
+     * everything. One variant is in blockContent (href), another in
+     * simpleBlockContent (internal/external). Would prefer to refactor the
+     * TextBlock approach, but it'd be a pretty big job.
+     */
+    link: ({ children, value }) => {
+      const url =
+        value?.href || value?.internal?.slug?.current || value?.external;
+      return url ? (
         <a
-          href={value.href}
+          href={url}
           {...(value?.blank ? { target: '_blank', rel: 'noreferrer' } : {})}
         >
           {children}
         </a>
       ) : (
         <>{children}</>
-      ),
+      );
+    },
   },
 };
 

--- a/web/pages/[[...slug]].tsx
+++ b/web/pages/[[...slug]].tsx
@@ -46,10 +46,6 @@ const QUERY = groq`
                 sponsors[]->,
                 "allSponsorships": *[_id == "${mainEventId}"][0].sponsorships[]->,
               },
-              _type == "simpleCallToAction" => {
-                ...,
-                reference->,
-              },
               _type == "venuesSection" => {
                 ...,
                 venues[]->,

--- a/web/pages/[[...slug]].tsx
+++ b/web/pages/[[...slug]].tsx
@@ -30,7 +30,10 @@ const QUERY = groq`
           ...,
           callToAction {
             ...,
-            reference->{slug},
+            link {
+              ...,
+              internal->{slug},
+            },
           },
         },
         sections[] {
@@ -69,7 +72,10 @@ const QUERY = groq`
               },
               content[] {
                 ...,
-                reference->,
+                link {
+                  ...,
+                  internal->{slug},
+                },
               },
             },
           },
@@ -116,7 +122,10 @@ const QUERY = groq`
             },
             content[] {
               ...,
-              reference->,
+              link {
+                ...,
+                internal->{slug},
+              },
             },
           },
         }

--- a/web/types/Link.ts
+++ b/web/types/Link.ts
@@ -1,0 +1,9 @@
+import { Slug } from './Slug';
+
+export type Link = {
+  internal?: {
+    slug?: Slug;
+  };
+  external?: string;
+  blank?: boolean;
+};

--- a/web/types/SimpleCallToAction.ts
+++ b/web/types/SimpleCallToAction.ts
@@ -1,9 +1,6 @@
-import { Slug } from './Slug';
+import { Link } from './Link';
 
 export type SimpleCallToAction = {
   text?: string;
-  url?: string;
-  reference?: {
-    slug?: Slug;
-  };
+  link?: Link;
 };

--- a/web/util/queries.ts
+++ b/web/util/queries.ts
@@ -15,6 +15,17 @@ const BLOCK_CONTENT = `
 `;
 const SIMPLE_BLOCK_CONTENT = `
   ...,
+  markDefs[] {
+    ...,
+    _type == "link" => {
+      external,
+      blank,
+      internal-> {
+        _type,
+        slug,
+      },
+    },
+  },
   _type == "simpleCallToAction" => { ${SIMPLE_CALL_TO_ACTION} },
 `;
 


### PR DESCRIPTION
# External links in new tab

## Intent

Open rich text "External link"s in a new tab if the "Open in new tab" setting has been switched on, and similarly for richtext "Link" objects and for "Simple call to action" objects.

## Description

This has been discussed in the Shortcut story "[Minor design implementation tweaks (first round)](https://app.shortcut.com/sanity-io/story/16013/minor-design-implementation-tweaks-first-round)", which includes this task ("Open new tab when clickling on external links"). This PR doesn't open _all_ external links in new tabs, just some of them. Mainly, those richtext or `simpleCallToAction` links where the "Open in new tab or window" setting has been enabled.

The PR also currently sets the "Tickets" links in header nav and "nav block" to open in a new tab, because it was requested by Sindre in the story. Would be good to have confirmation from @kmelve if this is OK or if it should be reverted. (As discussed in the story there are also other links that already open in new tabs prior to this PR, these are in the footer and cookie banner.)

## Testing this PR

1. Ensure you're using a browser config with the usual behavior of defaulting to opening links in the current tab (with the possible exception of downloads, non-HTTP/HTTPS URI schemes etc)
2. Open https://structured-content-2022-web-git-external-links-in-new-tab.sanity.build/link-testing
3. Verify that all links/button on the page are working (the ones marked "internal" point to the /programs page, and the ones marked "external" point to sanity.io) and that the ones marked "new tab" open in a new tab (or a new window if your browser is configured like that)