### PR TITLE
Use `staging` dataset locally and for Preview Deploys

### DIFF
--- a/studio/README.md
+++ b/studio/README.md
@@ -17,5 +17,16 @@ and an _.env_ file to the _/web_ directory. Fetch the value for this key [in the
 Once added, restart the project locally. After you've logged in to Sanity Studio, open a Route document, click the top-right meatball menu,
 and select "Open preview". That page will load draft content client-side after the initial render.
 
+## Environment variables
+
+To override defaults, add a _.env.development_ file to this _/studio_ directory. The file should not be committed to your repository. The
+following variables are supported:
+
+- SANITY_STUDIO_PREVIEW_SECRET: The secret used to enable Live Preview. (See above.)
+- SANITY_STUDIO_API_DATASET: The name of the dataset to use for the Sanity API. Defaults to `staging` locally and for Live Previews (due to
+  being set in the [Vercel project settings][1]), and `production` in production.
+  - Read more about supported Studio environment variables [here][2].
+
 [0]: https://www.sanity.io/guides/nextjs-live-preview
 [1]: https://vercel.com/sanity-io/structured-content-2022-studio/settings/environment-variables
+[2]: https://www.sanity.io/docs/studio-environment-variables

--- a/studio/sanity.json
+++ b/studio/sanity.json
@@ -35,5 +35,12 @@
       "implements": "part:@sanity/production-preview/resolve-production-url",
       "path": "./src/resolveProductionUrl.ts"
     }
-  ]
+  ],
+  "env": {
+    "development": {
+      "api": {
+        "dataset": "staging"
+      }
+    }
+  }
 }

--- a/web/README.md
+++ b/web/README.md
@@ -27,6 +27,8 @@ following variables are supported:
 
 - SANITY_STUDIO_API_DATASET: The name of the dataset to use for the Sanity API. If not specified, `staging` will be used
   locally and for Live Previews, and `production` in production.
+- SANITY_STUDIO_REVALIDATE_SECRET: Secret used by /revalidate endpoint (called by Studio) to revalidate pages. Set in the
+  [Vercel project's environment variables][env-vars].
 
 ## Learn More
 
@@ -42,3 +44,4 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 Will auto-deploy to production from the `main` branch. Pull Requests will also be deployed on their own staging URLs.
 
 [sc2022]: https://www.structuredcontent.live
+[env-vars]: https://vercel.com/sanity-io/structured-content-2022-web/settings/environment-variables

--- a/web/README.md
+++ b/web/README.md
@@ -20,6 +20,14 @@ yarn dev
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
+## Environment variables
+
+To override defaults, add a _.env_ file to this _/web_ directory. The file should not be committed to your repository. The
+following variables are supported:
+
+- SANITY_STUDIO_API_DATASET: The name of the dataset to use for the Sanity API. If not specified, `staging` will be used
+  locally and for Live Previews, and `production` in production.
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:

--- a/web/lib/config.js
+++ b/web/lib/config.js
@@ -1,7 +1,12 @@
 const projectConfig = {
   projectId: '33zsuc7i',
-  dataset: 'production',
+  dataset:
+    process.env.NEXT_PUBLIC_VERCEL_ENV === 'production'
+      ? 'production'
+      : 'staging',
 };
+
+console.log(`Using ${projectConfig.dataset} dataset`);
 
 const config = {
   sanity: {

--- a/web/lib/config.js
+++ b/web/lib/config.js
@@ -6,8 +6,6 @@ const projectConfig = {
       : 'staging',
 };
 
-console.log(`Using ${projectConfig.dataset} dataset`);
-
 const config = {
   sanity: {
     baseConfig: {

--- a/web/lib/config.js
+++ b/web/lib/config.js
@@ -1,9 +1,10 @@
 const projectConfig = {
   projectId: '33zsuc7i',
   dataset:
-    process.env.NEXT_PUBLIC_VERCEL_ENV === 'production'
+    process.env.SANITY_STUDIO_API_DATASET ||
+    (process.env.NEXT_PUBLIC_VERCEL_ENV === 'production'
       ? 'production'
-      : 'staging',
+      : 'staging'),
 };
 
 const config = {


### PR DESCRIPTION
# Use `staging` dataset locally and for Preview Deploys

## Intent

Use a one-off clone of the `production` dataset for local and staging/Preview development.

## Description

- Copied the `production` dataset to a new dataset named `staging` using `sanity dataset copy`
- Added `SANITY_STUDIO_API_DATASET=staging` dev & preview-only environment variable to [Studio's env vars](https://vercel.com/sanity-io/structured-content-2022-studio/settings/environment-variables)
- Added code changes which set the target dataset to `staging` unless running in a production environment

## Testing this PR

1. Start both _web_ and _studio_
2. Open [localhost:3000/test](http://localhost:3000/test) in your browser
3. Verify that the page renders _"Test update (staging change)."_ among other things
4. Open the [test article](http://localhost:3333/desk/article;72149d3a-1f8c-4be6-822c-ef313370c03d) locally in Studio and verify that the "staging change" is present in the article's content, proving that you're using the staging dataset
5. Verify that the corresponding [test article](https://admin.structuredcontent.live/desk/article;72149d3a-1f8c-4be6-822c-ef313370c03d) in production does not have the same change
6. Verify that the latest Preview Deploy for this PR renders the "staging change" output, whereas the corresponding [production URL](https://structuredcontent.live/test) does not
7. (optional) Perform changes to the test page both in production, locally and in Preview Deploy environments, and verify that they only affect expected parts (local Studio updates `staging` dataset, changes not visible in prod and vice versa, etc.) 
