### PR TITLE
Nav, NavBlock: 'Registration info' -> 'Registration'

### DIFF
--- a/web/components/Nav/Nav.tsx
+++ b/web/components/Nav/Nav.tsx
@@ -95,7 +95,7 @@ export const Nav = ({ onFrontPage, currentPath, ticketsUrl }: NavProps) => {
             />
             <BasicMenuItem
               urlPath="/registration-info"
-              label="Registration info"
+              label="Registration"
             />
             <BasicMenuItem urlPath="/about" label="About" />
           </ul>

--- a/web/components/NavBlock/NavBlock.tsx
+++ b/web/components/NavBlock/NavBlock.tsx
@@ -73,7 +73,7 @@ export const NavBlock = ({ ticketsUrl }: NavBlockProps) => (
 
       <li className={styles.item}>
         <Link href="/registration-info">
-          <a className={styles.link}>Registration info</a>
+          <a className={styles.link}>Registration</a>
         </Link>
       </li>
 


### PR DESCRIPTION
# Nav, NavBlock: 'Registration info' -> 'Registration'

## Intent

Fixes [this](https://app.shortcut.com/sanity-io/story/16305/text-change-registration-info-to-registration-in-main-nav-and-nav-block) Shortcut Story.

## Testing this PR

1. Open the Preview Deploy for this PR
2. Verify that the NavBlock item previously labeled "Registration info" is rendered as "Registration"
3. Scroll down until the Nav appears and verify that the same is the case for the Nav element