### PR TITLE
Refactor and fix GROQ queries

### DIFF
--- a/web/pages/[[...slug]].tsx
+++ b/web/pages/[[...slug]].tsx
@@ -30,7 +30,7 @@ import {
 import styles from './app.module.css';
 
 const SHARED_SECTIONS = `
-  ...,
+  _type,
   _type == "figure" => { ${FIGURE} },
   _type == "articleSection" => { ${ARTICLE_SECTION} },
   _type == "textAndImageSection" => { ${TEXT_AND_IMAGE_SECTION} },
@@ -67,6 +67,7 @@ const SHARED_SECTIONS = `
     tickets[]->{ ${TICKET} },
     "allTickets": *[_id == "${mainEventId}"][0].tickets[]->{ ${TICKET} }
   },
+  _type == "formSection" => { ... },
   _type == "programsSection" => {
     type,
     programs[]-> { ${PROGRAM} },

--- a/web/pages/[[...slug]].tsx
+++ b/web/pages/[[...slug]].tsx
@@ -19,8 +19,11 @@ import { Section } from '../types/Section';
 import { Hero as HeroProps } from '../types/Hero';
 import { mainEventId } from '../util/entityPaths';
 import {
+  ARTICLE_SECTION,
   FIGURE,
   HERO,
+  QUESTION_AND_ANSWER_COLLECTION_SECTION,
+  TEXT_AND_IMAGE_SECTION,
 } from '../util/queries';
 import styles from './app.module.css';
 
@@ -35,6 +38,12 @@ const QUERY = groq`
             ...,
             sections[] {
               ...,
+              _type == "figure" => { ${FIGURE} },
+              _type == "articleSection" => { ${ARTICLE_SECTION} },
+              _type == "textAndImageSection" => { ${TEXT_AND_IMAGE_SECTION} },
+              _type == "questionAndAnswerCollectionSection" => {
+                ${QUESTION_AND_ANSWER_COLLECTION_SECTION}
+              },
               _type == "sponsorsSection" => {
                 ...,
                 sponsors[]->,
@@ -72,6 +81,12 @@ const QUERY = groq`
           },
           _type != 'reference' => @ {
             ...,
+            _type == "figure" => { ${FIGURE} },
+            _type == "articleSection" => { ${ARTICLE_SECTION} },
+            _type == "textAndImageSection" => { ${TEXT_AND_IMAGE_SECTION} },
+            _type == "questionAndAnswerCollectionSection" => {
+              ${QUESTION_AND_ANSWER_COLLECTION_SECTION}
+            },
             _type == "ticketsSection" => {
               ...,
               tickets[]->,

--- a/web/pages/[[...slug]].tsx
+++ b/web/pages/[[...slug]].tsx
@@ -18,21 +18,18 @@ import { Slug } from '../types/Slug';
 import { Section } from '../types/Section';
 import { Hero as HeroProps } from '../types/Hero';
 import { mainEventId } from '../util/entityPaths';
+import {
+  FIGURE,
+  HERO,
+} from '../util/queries';
 import styles from './app.module.css';
 
 const QUERY = groq`
   {
     "route": *[_type == "route" && slug.current == $slug][0] {
-      ...,
+      seo { title, description, image { ${FIGURE} }, noIndex },
       page-> {
-        name,
-        hero {
-          ...,
-          callToAction {
-            ...,
-            reference->{slug},
-          },
-        },
+        hero { ${HERO} },
         sections[] {
           _type == 'reference' => @-> {
             ...,

--- a/web/pages/[[...slug]].tsx
+++ b/web/pages/[[...slug]].tsx
@@ -24,6 +24,7 @@ import {
   HERO,
   QUESTION_AND_ANSWER_COLLECTION_SECTION,
   TEXT_AND_IMAGE_SECTION,
+  TICKET,
 } from '../util/queries';
 import styles from './app.module.css';
 
@@ -61,9 +62,9 @@ const SHARED_SECTIONS = `
     "allSponsorships": *[_id == "${mainEventId}"][0].sponsorships[]->,
   },
   _type == "ticketsSection" => {
-    ...,
-    tickets[]->,
-    "allTickets": *[_id == "${mainEventId}"][0].tickets[]->
+    type,
+    tickets[]->{ ${TICKET} },
+    "allTickets": *[_id == "${mainEventId}"][0].tickets[]->{ ${TICKET} }
   },
   _type == "programsSection" => {
     ...,

--- a/web/pages/[[...slug]].tsx
+++ b/web/pages/[[...slug]].tsx
@@ -51,8 +51,8 @@ const QUERY = groq`
               },
               _type == "venuesSection" => {
                 ...,
-                venues[]->,
-                "allVenues": *[_id == "${mainEventId}"][0].venues[]->,
+                venues[]->{name},
+                "allVenues": *[_id == "${mainEventId}"][0].venues[]->{name},
               },
               _type == "sessionsSection" => {
                 ...,

--- a/web/pages/[[...slug]].tsx
+++ b/web/pages/[[...slug]].tsx
@@ -22,6 +22,7 @@ import {
   ARTICLE_SECTION,
   FIGURE,
   HERO,
+  PROGRAM,
   QUESTION_AND_ANSWER_COLLECTION_SECTION,
   TEXT_AND_IMAGE_SECTION,
   TICKET,
@@ -67,27 +68,9 @@ const SHARED_SECTIONS = `
     "allTickets": *[_id == "${mainEventId}"][0].tickets[]->{ ${TICKET} }
   },
   _type == "programsSection" => {
-    ...,
-    programs[]-> {
-      ...,
-      sessions[] {
-        ...,
-        session->,
-      },
-      venues[]->,
-    },
-    "allPrograms": *[_type == "program"] {
-      ...,
-      sessions[] {
-        ...,
-        session->,
-      },
-      venues[]->,
-    }
-  },
-  content[] {
-    ...,
-    reference->,
+    type,
+    programs[]-> { ${PROGRAM} },
+    "allPrograms": *[_type == "program"] { ${PROGRAM} }
   },
 `;
 

--- a/web/pages/[[...slug]].tsx
+++ b/web/pages/[[...slug]].tsx
@@ -27,6 +27,69 @@ import {
 } from '../util/queries';
 import styles from './app.module.css';
 
+const SHARED_SECTIONS = `
+  ...,
+  _type == "figure" => { ${FIGURE} },
+  _type == "articleSection" => { ${ARTICLE_SECTION} },
+  _type == "textAndImageSection" => { ${TEXT_AND_IMAGE_SECTION} },
+  _type == "questionAndAnswerCollectionSection" => {
+    ${QUESTION_AND_ANSWER_COLLECTION_SECTION}
+  },
+  _type == "speakersSection" => {
+    ...,
+    speakers[]->,
+    "allSpeakers": *[_type == "person"],
+  },
+  _type == "sessionsSection" => {
+    ...,
+    sessions[]->,
+    "allSessions": *[_type == "session"],
+  },
+  _type == "venuesSection" => {
+    ...,
+    venues[]->{name},
+    "allVenues": *[_id == "${mainEventId}"][0].venues[]->{name},
+  },
+  _type == "sponsorsSection" => {
+    ...,
+    sponsors[]->,
+    "allSponsorships": *[_id == "${mainEventId}"][0].sponsorships[]->,
+  },
+  _type == "sponsorshipsSection" => {
+    ...,
+    sponsors[]->,
+    "allSponsorships": *[_id == "${mainEventId}"][0].sponsorships[]->,
+  },
+  _type == "ticketsSection" => {
+    ...,
+    tickets[]->,
+    "allTickets": *[_id == "${mainEventId}"][0].tickets[]->
+  },
+  _type == "programsSection" => {
+    ...,
+    programs[]-> {
+      ...,
+      sessions[] {
+        ...,
+        session->,
+      },
+      venues[]->,
+    },
+    "allPrograms": *[_type == "program"] {
+      ...,
+      sessions[] {
+        ...,
+        session->,
+      },
+      venues[]->,
+    }
+  },
+  content[] {
+    ...,
+    reference->,
+  },
+`;
+
 const QUERY = groq`
   {
     "route": *[_type == "route" && slug.current == $slug][0] {
@@ -36,97 +99,9 @@ const QUERY = groq`
         sections[] {
           _type == 'reference' => @-> {
             ...,
-            sections[] {
-              ...,
-              _type == "figure" => { ${FIGURE} },
-              _type == "articleSection" => { ${ARTICLE_SECTION} },
-              _type == "textAndImageSection" => { ${TEXT_AND_IMAGE_SECTION} },
-              _type == "questionAndAnswerCollectionSection" => {
-                ${QUESTION_AND_ANSWER_COLLECTION_SECTION}
-              },
-              _type == "sponsorsSection" => {
-                ...,
-                sponsors[]->,
-                "allSponsorships": *[_id == "${mainEventId}"][0].sponsorships[]->,
-              },
-              _type == "venuesSection" => {
-                ...,
-                venues[]->{name},
-                "allVenues": *[_id == "${mainEventId}"][0].venues[]->{name},
-              },
-              _type == "sessionsSection" => {
-                ...,
-                sessions[]->,
-                "allSessions": *[_type == "session"],
-              },
-              _type == "speakersSection" => {
-                ...,
-                speakers[]->,
-                "allSpeakers": *[_type == "person"],
-              },              
-              _type == "ticketsSection" => {
-                ...,
-                tickets[]->,
-                "allTickets": *[_id == "${mainEventId}"][0].tickets[]->
-              },
-              content[] {
-                ...,
-                reference->,
-              },
-            },
+            sections[] { ${SHARED_SECTIONS} },
           },
-          _type != 'reference' => @ {
-            ...,
-            _type == "figure" => { ${FIGURE} },
-            _type == "articleSection" => { ${ARTICLE_SECTION} },
-            _type == "textAndImageSection" => { ${TEXT_AND_IMAGE_SECTION} },
-            _type == "questionAndAnswerCollectionSection" => {
-              ${QUESTION_AND_ANSWER_COLLECTION_SECTION}
-            },
-            _type == "ticketsSection" => {
-              ...,
-              tickets[]->,
-              "allTickets": *[_id == "${mainEventId}"][0].tickets[]->
-            },
-            _type == "venuesSection" => {
-              ...,
-              venues[]->,
-              "allVenues": *[_id == "${mainEventId}"][0].venues[]->,
-            },
-            _type == "sponsorshipsSection" => {
-              ...,
-              sponsors[]->,
-              "allSponsorships": *[_id == "${mainEventId}"][0].sponsorships[]->,
-            },
-            _type == "sponsorsSection" => {
-              ...,
-              sponsors[]->,
-              "allSponsorships": *[_id == "${mainEventId}"][0].sponsorships[]->,
-            },
-            _type == "programsSection" => {
-              ...,
-              programs[]-> {
-                ...,
-                sessions[] {
-                  ...,
-                  session->,
-                },
-                venues[]->,
-              },
-              "allPrograms": *[_type == "program"] {
-                ...,
-                sessions[] {
-                  ...,
-                  session->,
-                },
-                venues[]->,
-              }
-            },
-            content[] {
-              ...,
-              reference->,
-            },
-          },
+          _type != 'reference' => @ { ${SHARED_SECTIONS} }
         }
       }
     },

--- a/web/pages/[[...slug]].tsx
+++ b/web/pages/[[...slug]].tsx
@@ -49,10 +49,6 @@ const QUERY = groq`
                 sponsors[]->,
                 "allSponsorships": *[_id == "${mainEventId}"][0].sponsorships[]->,
               },
-              _type == "simpleCallToAction" => {
-                ...,
-                reference->,
-              },
               _type == "venuesSection" => {
                 ...,
                 venues[]->,

--- a/web/pages/[[...slug]].tsx
+++ b/web/pages/[[...slug]].tsx
@@ -84,7 +84,7 @@ const QUERY = groq`
         sections[] {
           _type == 'reference' => @-> {
             ...,
-            sections[] { ${SHARED_SECTIONS} },
+            sections[] { _key, ${SHARED_SECTIONS} },
           },
           _type != 'reference' => @ { ${SHARED_SECTIONS} }
         }

--- a/web/pages/article/[slug].tsx
+++ b/web/pages/article/[slug].tsx
@@ -13,21 +13,15 @@ import { Article } from '../../types/Article';
 import articleStyles from './article.module.css';
 import styles from '../app.module.css';
 import MetaTags from '../../components/MetaTags';
+import { BLOCK_CONTENT } from '../../util/queries';
 
 const QUERY = groq`
   {
     "article": *[_type == "article" && slug.current == $slug][0] {
-      ...,
-      content[] {
-        ...,
-        markDefs[] {
-          ...,
-          reference-> {
-            _type,
-            slug,
-          },
-        },
-      },
+      _id,
+      heading,
+      summary,
+      content[] { ${BLOCK_CONTENT} },
     },
     "home": *[_id == "${mainEventId}"][0] {
       "ticketsUrl": microcopy[key == "mainCta"][0].action,

--- a/web/types/Program.ts
+++ b/web/types/Program.ts
@@ -2,14 +2,7 @@ import { Session } from './Session';
 import { Venue } from './Venue';
 
 export type Program = {
-  _createdAt: string;
   _id: string;
-  _rev: string;
-  _type: 'program';
-  event: {
-    _ref: string;
-    type: 'reference';
-  };
   internalName: string;
   sessions: {
     duration?: number;

--- a/web/util/queries.ts
+++ b/web/util/queries.ts
@@ -8,6 +8,16 @@ const SIMPLE_BLOCK_CONTENT = `
 
 const ARTICLE_SECTION = `heading, subheading, content[]{ ${SIMPLE_BLOCK_CONTENT} }`;
 const HERO = `heading, summary, callToAction{ ${SIMPLE_CALL_TO_ACTION} }`;
+const PROGRAM = `
+  _id,
+  internalName,
+  startDateTime,
+  sessions[] {
+    ...,
+    session->{ duration, title },
+  },
+  venues[]->{ name, timezone },
+`;
 const QUESTION_AND_ANSWER_COLLECTION_SECTION = `
   title, questions[]{ _key, question, answer[]{ ${SIMPLE_BLOCK_CONTENT} } }
 `;
@@ -27,6 +37,7 @@ export {
   ARTICLE_SECTION,
   FIGURE,
   HERO,
+  PROGRAM,
   QUESTION_AND_ANSWER_COLLECTION_SECTION,
   SIMPLE_CALL_TO_ACTION,
   TEXT_AND_IMAGE_SECTION,

--- a/web/util/queries.ts
+++ b/web/util/queries.ts
@@ -1,10 +1,25 @@
 const FIGURE = '_type, alt, asset';
 const SIMPLE_CALL_TO_ACTION = 'text, url, reference->{slug}';
 
+const SIMPLE_BLOCK_CONTENT = `
+  ...,
+  _type == "simpleCallToAction" => { ${SIMPLE_CALL_TO_ACTION} },
+`;
+
+const ARTICLE_SECTION = `heading, subheading, content[]{ ${SIMPLE_BLOCK_CONTENT} }`;
 const HERO = `heading, summary, callToAction{ ${SIMPLE_CALL_TO_ACTION} }`;
+const QUESTION_AND_ANSWER_COLLECTION_SECTION = `
+  title, questions[]{ _key, question, answer[]{ ${SIMPLE_BLOCK_CONTENT} } }
+`;
+const TEXT_AND_IMAGE_SECTION = `
+  title, tagline, text[]{ ${SIMPLE_BLOCK_CONTENT} }, image{ ${FIGURE} }
+`;
 
 export {
+  ARTICLE_SECTION,
   FIGURE,
   HERO,
+  QUESTION_AND_ANSWER_COLLECTION_SECTION,
   SIMPLE_CALL_TO_ACTION,
+  TEXT_AND_IMAGE_SECTION,
 };

--- a/web/util/queries.ts
+++ b/web/util/queries.ts
@@ -1,0 +1,10 @@
+const FIGURE = '_type, alt, asset';
+const SIMPLE_CALL_TO_ACTION = 'text, url, reference->{slug}';
+
+const HERO = `heading, summary, callToAction{ ${SIMPLE_CALL_TO_ACTION} }`;
+
+export {
+  FIGURE,
+  HERO,
+  SIMPLE_CALL_TO_ACTION,
+};

--- a/web/util/queries.ts
+++ b/web/util/queries.ts
@@ -14,6 +14,14 @@ const QUESTION_AND_ANSWER_COLLECTION_SECTION = `
 const TEXT_AND_IMAGE_SECTION = `
   title, tagline, text[]{ ${SIMPLE_BLOCK_CONTENT} }, image{ ${FIGURE} }
 `;
+const TICKET = `
+  _id,
+  _type,
+  description[]{ ${SIMPLE_BLOCK_CONTENT} },
+  included,
+  priceAndAvailability,
+  type,
+`;
 
 export {
   ARTICLE_SECTION,
@@ -22,4 +30,5 @@ export {
   QUESTION_AND_ANSWER_COLLECTION_SECTION,
   SIMPLE_CALL_TO_ACTION,
   TEXT_AND_IMAGE_SECTION,
+  TICKET,
 };

--- a/web/util/queries.ts
+++ b/web/util/queries.ts
@@ -1,6 +1,16 @@
 const FIGURE = '_type, alt, asset';
 const SIMPLE_CALL_TO_ACTION = 'text, url, reference->{slug}';
 
+const BLOCK_CONTENT = `
+  ...,
+  markDefs[] {
+    ...,
+    reference-> {
+      _type,
+      slug,
+    },
+  },
+`;
 const SIMPLE_BLOCK_CONTENT = `
   ...,
   _type == "simpleCallToAction" => { ${SIMPLE_CALL_TO_ACTION} },
@@ -35,6 +45,7 @@ const TICKET = `
 
 export {
   ARTICLE_SECTION,
+  BLOCK_CONTENT,
   FIGURE,
   HERO,
   PROGRAM,


### PR DESCRIPTION
# Refactor and fix GROQ queries

## Intent

Rework the GROQ queries, particularly the one for `page` documents with their sections array, with projections so that things like `simpleBlockContent` are defined explicitly in one place, for consistent support of things like internal links and CTAs that are given by references (which need to be expanded in the query).

Also to try to limit the amount of JSON data we load on the client, by using projections to get only what we actually need, as described in a [previously mentioned blog post](https://www.sanity.io/blog/3-simple-things-in-groq-to-supercharge-your-frontend-development#db26fcd247c4).

See Shortcut story ["Refactor GROQ queries and fix external links"](https://app.shortcut.com/sanity-io/story/16228/refactor-groq-queries-and-fix-internal-links)

## Description

As the Shortcut story indicates, this is related to (and is regarded as blocking for) https://github.com/sanity-io/structured-content-2022/pull/111. That PR/branch includes some changes to the Sanity content model's treatment of links, which necessitated updating the parts of the query/-ies that relate to (simple) block content fields. It turned out these fields weren't always specified, which didn't seem like a straightforward thing to resolve. Hence I split it out as a separate story/task/PR, to limit scope.

As a further scope-limiting measure, I've mostly focused on sections that are in active use and that involve block content or call to action fields. E.g. I have not updated the projection for Sponsors/Sponsorships sections. The (shared) sections testing pages already seem to trigger errors and warnings for some of these even on staging.

## Testing this PR

1. Open the [/sections-testing](https://structured-content-2022-web-git-refactor-and-fix-groq-queries.sanity.build/sections-testing) page
2. Scroll down to the Q&A section ("First question" etc) and verify that the "CTA within Q&A →" link shows up (looks like a button)
3. Optionally, check other pages as well and verify that no sections/content is missing

Note that the Q&A heading now also shows up. This is visible both on the /sections-testing page and on [/shared-sections](https://structured-content-2022-web-git-refactor-and-fix-groq-queries.sanity.build/shared-sections)
