### PR TITLE
add more advanced benefits lists for sponsorships

### DIFF
--- a/studio/schemas/documents/benefit.ts
+++ b/studio/schemas/documents/benefit.ts
@@ -1,0 +1,12 @@
+export default {
+  name: "benefit",
+  title: "Sponsporship benefit",
+  type: "document",
+  fields: [
+    {
+      name: "name",
+      title: "Name",
+      type: "string",
+    },
+  ],
+};

--- a/studio/schemas/documents/sponsorship.ts
+++ b/studio/schemas/documents/sponsorship.ts
@@ -1,5 +1,38 @@
 import { CreditCardIcon } from "@sanity/icons";
 
+const offeringBenefits = [
+  {
+    title: "Logo + link on conference website",
+    value: "Logo + link on conference website",
+  },
+  {
+    title: "Logo + link on conference website - Premium location",
+    value: "Logo + link on conference website - Premium location",
+  },
+  {
+    title: "Social media mention - Group post",
+    value: "Social media mention - Group post",
+  },
+  {
+    title: "Social media mention - Dedicated post",
+    value: "Social media mention - Dedicated post",
+  },
+  { title: "On-stage mention", value: "On-stage mention" },
+  { title: "Virtual booth", value: "Virtual booth" },
+  {
+    title: "Sizzle reel spot - Before keynote & 1 talk of choice",
+    value: "Sizzle reel spot - Before keynote & 1 talk of choice",
+  },
+  {
+    title: "Sizzle reel spot - Before 1 talk of choice",
+    value: "Sizzle reel spot - Before 1 talk of choice",
+  },
+  {
+    title: "Sponsor a talk of your choice",
+    value: "Sponsor a talk of your choice",
+  },
+];
+
 export default {
   name: "sponsorship",
   title: "Sponsorships",
@@ -37,74 +70,49 @@ export default {
       validation: (Rule) => Rule.min(0),
     },
     {
-      name: "offering",
+      name: "benefits",
       type: "array",
-      title: "Offering",
-      options: {
-        list: [
-          {
-            title: "Logo + link on conference website",
-            value: "Logo + link on conference website",
-          },
-          {
-            title: "Logo + link on conference website - Premium location",
-            value: "Logo + link on conference website - Premium location",
-          },
-          {
-            title: "Social media mention - Group post",
-            value: "Social media mention - Group post",
-          },
-          {
-            title: "Social media mention - Dedicated post",
-            value: "Social media mention - Dedicated post",
-          },
-          { title: "On-stage mention", value: "On-stage mention" },
-          { title: "Virtual booth", value: "Virtual booth" },
-          {
-            title: "Sizzle reel spot - Before keynote & 1 talk of choice",
-            value: "Sizzle reel spot - Before keynote & 1 talk of choice",
-          },
-          {
-            title: "Sizzle reel spot - Before 1 talk of choice",
-            value: "Sizzle reel spot - Before 1 talk of choice",
-          },
-          {
-            title: "Sponsor a talk of your choice",
-            value: "Sponsor a talk of your choice",
-          },
-        ],
-      },
+      title: "Benefits",
       of: [
         {
-          type: "string",
-        },
-      ],
-    },
-    {
-      name: "passes",
-      type: "object",
-      title: "Included passes",
-      options: {
-        columns: 3,
-      },
-      fields: [
-        {
-          name: "online",
-          type: "number",
-          title: "Online passes",
-          validation: (Rule) => Rule.min(0),
-        },
-        {
-          name: "inPerson",
-          type: "number",
-          title: "In-person passes",
-          validation: (Rule) => Rule.min(0),
-        },
-        {
-          name: "workshop",
-          type: "number",
-          title: "Workshop passes",
-          validation: (Rule) => Rule.min(0),
+          type: "object",
+          name: "benefit",
+          title: "Benefit",
+          preview: {
+            select: {
+              name: "benefit.name",
+              number: "number",
+              description: "description",
+            },
+            prepare({ name, number, description = "" }) {
+              return {
+                title: name,
+                subtitle: `${number ? number : "☑️"} ${description}`,
+              };
+            },
+          },
+          fields: [
+            {
+              name: "benefit",
+              title: "Benefit",
+              type: "reference",
+              to: [{ type: "benefit" }],
+            },
+            {
+              name: "number",
+              title: "Number",
+              type: "number",
+              validation: (Rule) => Rule.min(0),
+              description:
+                "Specify number. Use 0 or remove this item to disable this benefit. Leave blank for ☑️.",
+            },
+            {
+              name: "description",
+              title: "Description",
+              type: "string",
+              description: "Add unit of measure, or other tiny clarifycations.",
+            },
+          ],
         },
       ],
     },

--- a/studio/schemas/schema.ts
+++ b/studio/schemas/schema.ts
@@ -24,12 +24,14 @@ import * as sections from "./sections";
 
 import spec from "./documents/spec";
 import program from "./documents/program";
+import benefit from "./documents/benefit";
 
 export default createSchema({
   name: "default",
   types: schemaTypes.concat([
     ...Object.values(sections),
     figure,
+    benefit,
     questionAndAnswer,
     simpleCallToAction,
     richText,


### PR DESCRIPTION
# Add more advanced benefits lists for sponsorships

## Intent

Express unique measures on shared benefits across sponsorship packages.

## Description

This introduces a new list and a new document type for benefits. The document type is not yet added to the overall structure but is available through the new array field. The thinking is that the entry of a benefit will make its boolean status `true`. If you add a number, then it will override the boolean status. It's an open question if 0 should say 0 or make it `false`. 

This introduces a data model change and content needs to migrated.