### PR TITLE
New link structure for articles

### DIFF
--- a/studio/schemas/arrays/blockContent.ts
+++ b/studio/schemas/arrays/blockContent.ts
@@ -22,9 +22,6 @@ export default {
             { type: "ticket" },
           ],
         },
-        {
-          type: "simpleCallToAction",
-        },
       ],
       marks: {
         decorators: [
@@ -40,6 +37,9 @@ export default {
           },
         ],
       },
+    },
+    {
+      type: "simpleCallToAction",
     },
   ],
 };

--- a/web/components/SimpleCallToAction/SimpleCallToAction.tsx
+++ b/web/components/SimpleCallToAction/SimpleCallToAction.tsx
@@ -1,6 +1,6 @@
 import { SimpleCallToAction as SimpleCallToActionProps } from '../../types/SimpleCallToAction';
 import ButtonLink from '../ButtonLink';
-import urlJoin from 'proper-url-join';
+import { getEntityPath } from '../../util/entityPaths';
 
 export const SimpleCallToAction = ({ text, link }: SimpleCallToActionProps) => {
   const openInNewTab = Boolean(link?.blank);
@@ -8,7 +8,10 @@ export const SimpleCallToAction = ({ text, link }: SimpleCallToActionProps) => {
     return (
       <ButtonLink
         text={text}
-        url={urlJoin(link.internal.slug.current)}
+        url={getEntityPath({
+          _type: link.internal._type,
+          slug: link.internal.slug,
+        })}
         openInNewTab={openInNewTab}
       />
     );

--- a/web/components/SimpleCallToAction/SimpleCallToAction.tsx
+++ b/web/components/SimpleCallToAction/SimpleCallToAction.tsx
@@ -8,10 +8,7 @@ export const SimpleCallToAction = ({ text, link }: SimpleCallToActionProps) => {
     return (
       <ButtonLink
         text={text}
-        url={getEntityPath({
-          _type: link.internal._type,
-          slug: link.internal.slug,
-        })}
+        url={getEntityPath(link.internal)}
         openInNewTab={openInNewTab}
       />
     );

--- a/web/components/TextBlock/TextBlock/TextBlock.tsx
+++ b/web/components/TextBlock/TextBlock/TextBlock.tsx
@@ -45,14 +45,11 @@ const components: Partial<PortableTextComponents> = {
       /* href has been seen in a case where both link and internalLink marks applied */
       <Link href={value?.href || getEntityPath(value.reference)}>{text}</Link>
     ),
-    /* There are two different link marks, but currently TextBlock is used for
-     * everything. One variant is in blockContent (href), another in
-     * simpleBlockContent (internal/external). Would prefer to refactor the
-     * TextBlock approach, but it'd be a pretty big job.
-     */
     link: ({ children, value }) => {
-      const url =
-        value?.href || value?.internal?.slug?.current || value?.external;
+      const resolvedSlug = value?.internal?.slug?.current
+        ? getEntityPath(value.internal)
+        : null;
+      const url = resolvedSlug || value?.external;
       return url ? (
         <a
           href={url}

--- a/web/components/TextBlock/TextBlock/TextBlock.tsx
+++ b/web/components/TextBlock/TextBlock/TextBlock.tsx
@@ -41,10 +41,6 @@ const components: Partial<PortableTextComponents> = {
     italic: ({ children }) => <em>{children}</em>,
     underline: ({ children }) => <u>{children}</u>,
     code: ({ children }) => <code>{children}</code>,
-    internalLink: ({ text, value }) => (
-      /* href has been seen in a case where both link and internalLink marks applied */
-      <Link href={value?.href || getEntityPath(value.reference)}>{text}</Link>
-    ),
     link: ({ children, value }) => {
       const resolvedSlug = value?.internal?.slug?.current
         ? getEntityPath(value.internal)

--- a/web/components/TextBlock/TextBlock/TextBlock.tsx
+++ b/web/components/TextBlock/TextBlock/TextBlock.tsx
@@ -42,10 +42,7 @@ const components: Partial<PortableTextComponents> = {
     underline: ({ children }) => <u>{children}</u>,
     code: ({ children }) => <code>{children}</code>,
     link: ({ children, value }) => {
-      const resolvedSlug = value?.internal?.slug?.current
-        ? getEntityPath(value.internal)
-        : null;
-      const url = resolvedSlug || value?.external;
+      const url = getEntityPath(value?.internal) || value?.external;
       return url ? (
         <a
           href={url}

--- a/web/types/Link.ts
+++ b/web/types/Link.ts
@@ -2,6 +2,7 @@ import { Slug } from './Slug';
 
 export type Link = {
   internal?: {
+    _type: string;
     slug?: Slug;
   };
   external?: string;

--- a/web/util/entityPaths.ts
+++ b/web/util/entityPaths.ts
@@ -3,7 +3,7 @@ import { Slug } from '../types/Slug';
 
 export const mainEventId = 'aad77280-6394-4090-afad-1c0f2a0416c6';
 
-export const getEntityPath = (entity?: { _type: string; slug: Slug }) => {
+export const getEntityPath = (entity?: { _type: string; slug?: Slug }) => {
   if (!entity?.slug?.current) {
     return '#';
   }

--- a/web/util/entityPaths.ts
+++ b/web/util/entityPaths.ts
@@ -4,8 +4,11 @@ import { Slug } from '../types/Slug';
 export const mainEventId = 'aad77280-6394-4090-afad-1c0f2a0416c6';
 
 export const getEntityPath = (entity?: { _type: string; slug?: Slug }) => {
+  /* Should quite possibly return null instead, but this will require some
+   * refactoring. The empty string is falsy, at least, which is useful.
+   */
   if (!entity?.slug?.current) {
-    return '#';
+    return '';
   }
 
   switch (entity._type) {
@@ -17,6 +20,6 @@ export const getEntityPath = (entity?: { _type: string; slug?: Slug }) => {
       console.error(
         `getEntityPath: unsupported entity type: '${entity._type}'`
       );
-      return '#';
+      return '';
   }
 };

--- a/web/util/queries.ts
+++ b/web/util/queries.ts
@@ -1,4 +1,5 @@
 const LINK = 'internal->{slug}, external, blank';
+const LINK_MARK = 'internal->{_type, slug}, external, blank';
 
 const FIGURE = '_type, alt, asset';
 const SIMPLE_CALL_TO_ACTION = `text, link{ ${LINK} }`;
@@ -7,24 +8,14 @@ const BLOCK_CONTENT = `
   ...,
   markDefs[] {
     ...,
-    reference-> {
-      _type,
-      slug,
-    },
+    _type == "link" => { ${LINK_MARK} },
   },
 `;
 const SIMPLE_BLOCK_CONTENT = `
   ...,
   markDefs[] {
     ...,
-    _type == "link" => {
-      external,
-      blank,
-      internal-> {
-        _type,
-        slug,
-      },
-    },
+    _type == "link" => { ${LINK_MARK} },
   },
   _type == "simpleCallToAction" => { ${SIMPLE_CALL_TO_ACTION} },
 `;

--- a/web/util/queries.ts
+++ b/web/util/queries.ts
@@ -1,5 +1,4 @@
-const LINK = 'internal->{slug}, external, blank';
-const LINK_MARK = 'internal->{_type, slug}, external, blank';
+const LINK = 'internal->{_type, slug}, external, blank';
 
 const FIGURE = '_type, alt, asset';
 const SIMPLE_CALL_TO_ACTION = `text, link{ ${LINK} }`;
@@ -12,14 +11,14 @@ const BLOCK_CONTENT = `
   },
   markDefs[] {
     ...,
-    _type == "link" => { ${LINK_MARK} },
+    _type == "link" => { ${LINK} },
   },
 `;
 const SIMPLE_BLOCK_CONTENT = `
   ...,
   markDefs[] {
     ...,
-    _type == "link" => { ${LINK_MARK} },
+    _type == "link" => { ${LINK} },
   },
   _type == "simpleCallToAction" => { ${SIMPLE_CALL_TO_ACTION} },
 `;

--- a/web/util/queries.ts
+++ b/web/util/queries.ts
@@ -6,6 +6,10 @@ const SIMPLE_CALL_TO_ACTION = `text, link{ ${LINK} }`;
 
 const BLOCK_CONTENT = `
   ...,
+  children[] {
+    ...,
+    _type == "simpleCallToAction" => { ${SIMPLE_CALL_TO_ACTION} },
+  },
   markDefs[] {
     ...,
     _type == "link" => { ${LINK_MARK} },

--- a/web/util/queries.ts
+++ b/web/util/queries.ts
@@ -5,14 +5,11 @@ const SIMPLE_CALL_TO_ACTION = `text, link{ ${LINK} }`;
 
 const BLOCK_CONTENT = `
   ...,
-  children[] {
-    ...,
-    _type == "simpleCallToAction" => { ${SIMPLE_CALL_TO_ACTION} },
-  },
   markDefs[] {
     ...,
     _type == "link" => { ${LINK} },
   },
+  _type == "simpleCallToAction" => { ${SIMPLE_CALL_TO_ACTION} },
 `;
 const SIMPLE_BLOCK_CONTENT = `
   ...,


### PR DESCRIPTION
# New link structure for articles

Note: Should not be merged without coordinating the corresponding migration of the live content. This PR is not "backwards compatible" with the old link structure.

## Intent

Update the app code according to the new Sanity schema for links in `blockContent`, which is a rich text type that's primarily used in article content. See also Shortcut story [New links structure for articles](https://app.shortcut.com/sanity-io/story/16694/new-links-structure-for-articles)

## Description

This corresponds to a [commit that was pushed to PR 111](https://github.com/sanity-io/structured-content-2022/pull/111/commits/95a8e56b7412a174240d53922e117a37329d098b). Ideally we would have followed up on that same PR, but I've been busy on other projects myself, so the PR ended up being merged without corresponding changes to `/web`.

I've also updated the `simpleCallToAction` support for `blockContent` fields, which is somewhat related (it also uses the new link structure). It seems slightly odd to me that this is embedded differently in `blockContent` vs `simpleBlockContent`—the former allows it as inline content _within_ a block, while the latter has it as a possible object to mix _in between_ blocks. Is this intentional, @kmelve ?

I also changed one more thing about `SimpleCallToAction`: previously, this was using URLs of the form `/slug`, relying on the rewrites for articles. This seemed inconsistent with the existing (old) `internalLink` support, which used `getEntityPath`. Now this helper is used in both places, which also seems in line with the "/article/slug" URL being tagged as the "canonical" one.

## Testing this PR

For comparison purposes, I've left the existing `staging` content (such as /article/test) alone and created a new article with examples for the new schema.

1. Open https://structured-content-2022-web-git-new-link-structure-for-articles.sanity.build/article/test-links
2. Verify that all the links in the article body are working:
    - "External link" (sanity.io in new tab/window)
    - "Internal link" (Program page in same tab/window)
    - "Program →" (Program page in same tab/window)
    - "Test" →" (Test article in same tab/window)