### PR TITLE
Hotfix: fetch registrationUrl from main event

### DIFF
--- a/web/pages/article/[slug].tsx
+++ b/web/pages/article/[slug].tsx
@@ -24,7 +24,7 @@ const QUERY = groq`
       content[] { ${BLOCK_CONTENT} },
     },
     "home": *[_id == "${mainEventId}"][0] {
-      "ticketsUrl": microcopy[key == "mainCta"][0].action,
+      "ticketsUrl": registrationUrl,
     },
     "footer": *[_id == "secondary-nav"][0] {
       "links": tree[].value.reference-> {


### PR DESCRIPTION
# Hotfix: fetch registrationUrl from main event

## Intent

Fixes fetching of `registrationUrl`

## Testing this PR

Verify that the "Tickets" links in the Header and Nav work again in the PR's Preview Deploy.