### PR TITLE
[[...slug]].tsx: fetch registrationUrl from main event

### DIFF
--- a/web/components/Nav/Nav.tsx
+++ b/web/components/Nav/Nav.tsx
@@ -97,10 +97,7 @@ export const Nav = ({ onFrontPage, currentPath, ticketsUrl }: NavProps) => {
               urlPath="/sponsorship-information"
               label="Sponsorship"
             />
-            <BasicMenuItem
-              urlPath="/registration-info"
-              label="Registration"
-            />
+            <BasicMenuItem urlPath="/registration-info" label="Registration" />
             <BasicMenuItem urlPath="/about" label="About" />
           </ul>
           <div className={styles.ticketButton}>

--- a/web/next.config.js
+++ b/web/next.config.js
@@ -1,4 +1,5 @@
 const client = require('./lib/sanity.server');
+const { mainEventId } = require('./util/constants');
 
 module.exports = {
   reactStrictMode: true,
@@ -6,26 +7,19 @@ module.exports = {
     domains: ['cdn.sanity.io'],
   },
   async redirects() {
-    // ".microcopy[key == "mainCta"]" filtering does not work, so we have to filter server side
-    const microCopy = await client.fetch(
-      `*[_id == "aad77280-6394-4090-afad-1c0f2a0416c6"][0].microcopy[]`
+    const registrationUrl = await client.fetch(
+      `*[_id == "${mainEventId}"][0].registrationUrl`
     );
-    if (!Array.isArray(microCopy) || !microCopy.length) {
-      console.error("Could not find 'microcopy' attribute of main event!");
+    if (!registrationUrl) {
+      console.error("Could not find 'registrationUrl' of main event!");
       return [];
     }
 
-    const mainCta = microCopy.find((microCopy) => microCopy.key === 'mainCta');
-    if (!mainCta?.action) {
-      console.error("Could not find 'mainCta' element in microcopy array!");
-      return [];
-    }
-
-    console.log(`Redirecting /tickets to ${mainCta.action}`);
+    console.log(`Redirecting /tickets to ${registrationUrl}`);
     return [
       {
         source: '/tickets',
-        destination: mainCta.action,
+        destination: registrationUrl,
         permanent: true,
       },
     ];

--- a/web/pages/[[...slug]].tsx
+++ b/web/pages/[[...slug]].tsx
@@ -93,7 +93,7 @@ const QUERY = groq`
     "home": *[_id == "${mainEventId}"][0] {
       name,
       description,
-      "ticketsUrl": microcopy[key == "mainCta"][0].action,
+      "ticketsUrl": registrationUrl,
     },
     "footer": *[_id == "secondary-nav"][0] {
       "links": tree[].value.reference-> {

--- a/web/pages/[[...slug]].tsx
+++ b/web/pages/[[...slug]].tsx
@@ -17,7 +17,7 @@ import { Figure } from '../types/Figure';
 import { Slug } from '../types/Slug';
 import { Section } from '../types/Section';
 import { Hero as HeroProps } from '../types/Hero';
-import { mainEventId } from '../util/entityPaths';
+import { mainEventId } from '../util/constants';
 import {
   ARTICLE_SECTION,
   FIGURE,

--- a/web/pages/article/[slug].tsx
+++ b/web/pages/article/[slug].tsx
@@ -7,7 +7,7 @@ import Footer from '../../components/Footer';
 import Nav from '../../components/Nav';
 import client from '../../lib/sanity.server';
 import { Slug } from '../../types/Slug';
-import { mainEventId } from '../../util/entityPaths';
+import { mainEventId } from '../../util/constants';
 import GridWrapper from '../../components/GridWrapper';
 import { Article } from '../../types/Article';
 import articleStyles from './article.module.css';

--- a/web/util/constants.js
+++ b/web/util/constants.js
@@ -1,0 +1,4 @@
+// This file needs to be CJS due to it being referenced by next.config.js.
+module.exports = {
+  mainEventId: 'aad77280-6394-4090-afad-1c0f2a0416c6',
+};

--- a/web/util/entityPaths.ts
+++ b/web/util/entityPaths.ts
@@ -1,8 +1,6 @@
 import urlJoin from 'proper-url-join';
 import { Slug } from '../types/Slug';
 
-export const mainEventId = 'aad77280-6394-4090-afad-1c0f2a0416c6';
-
 export const getEntityPath = (entity?: { _type: string; slug: Slug }) => {
   if (!entity?.slug?.current) {
     return '#';


### PR DESCRIPTION
# [[...slug]].tsx: fetch registrationUrl from main event

## Intent

Fetch `registrationUrl` correctly for _[[...slug]].tsx_ too, unlike #128 which only does so for editorial articles.

## Description

I've deleted the `staging` dataset and copied `production` into `staging` anew. 

## Testing this PR

Verify that the "Tickets" links in the Header and Nav work again in the PR's Preview Deploy.