### PR TITLE
Fix duplicate Nav Tickets

### DIFF
--- a/web/components/Nav/MenuItem/MenuItem.tsx
+++ b/web/components/Nav/MenuItem/MenuItem.tsx
@@ -15,15 +15,11 @@ export const MenuItem = ({
   closeMenu,
   ...rest
 }: MenuItemProps) => (
-  <li>
+  <li className={className}>
     <Link href={href}>
       <a
         {...rest}
-        className={clsx(
-          styles.link,
-          href === currentPath && styles.current,
-          className
-        )}
+        className={clsx(styles.link, href === currentPath && styles.current)}
         onClick={closeMenu}
       />
     </Link>


### PR DESCRIPTION
# Fix duplicate Nav Tickets

## Intent

Fix a regression found by Sindre, where "Tickets" would appear both as a regular menu item and as a button in the menu bar (which is used when the window width is wide enough to trigger the "tablet" breakpoint in the design).

## Description

Fixes a misplaced class name (details in commit message).

## Testing this PR

1. Open https://structured-content-2022-web-git-fix-duplicate-nav-tickets.sanity.build/program
2. Make sure the window is wide enough that a menu bar with white background appears at the top of the page (i.e. around 768px or wider)
3. Verify that the menu bar contains "Program", "Sponsorship", "Registration" and "About", and that "Tickets" only appears as a yellow button (with an arrow), not also as a link alongside those other four entries
