### PR TITLE
MetaTags.tsx: absolute path for fallback OG image

### DIFF
--- a/web/components/MetaTags/MetaTags.tsx
+++ b/web/components/MetaTags/MetaTags.tsx
@@ -3,6 +3,7 @@ import urlJoin from 'proper-url-join';
 import opengraphImage from '../../images/opengraph-image.png';
 import { imageUrlFor } from '../../lib/sanity';
 import { Figure } from '../../types/Figure';
+import { productionUrl } from '../../util/constants';
 
 interface MetaTagsProps {
   title: string;
@@ -33,7 +34,7 @@ export const MetaTags = ({
     <NextSeo
       title={title}
       description={description}
-      canonical={urlJoin('https://structuredcontent.live', canonicalPath)}
+      canonical={urlJoin(productionUrl, canonicalPath)}
       noindex={noIndex}
       openGraph={{
         images: [
@@ -46,7 +47,7 @@ export const MetaTags = ({
                 alt: image.alt,
               }
             : {
-                url: opengraphImage.src,
+                url: urlJoin(productionUrl, opengraphImage.src),
                 width: opengraphImage.width,
                 height: opengraphImage.height,
               },

--- a/web/util/constants.js
+++ b/web/util/constants.js
@@ -1,4 +1,5 @@
 // This file needs to be CJS due to it being referenced by next.config.js.
 module.exports = {
   mainEventId: 'aad77280-6394-4090-afad-1c0f2a0416c6',
+  productionUrl: 'https://structuredcontent.live',
 };


### PR DESCRIPTION
# MetaTags.tsx: absolute path for fallback OG image

## Intent

FIxes [this](https://app.shortcut.com/sanity-io/story/16921/default-seo-image-url-isn-t-picked-up) Shortcut Story.

## Testing this PR

1. Go to https://www.bannerbear.com/tools/twitter-card-preview-tool/
2. Enter the Preview URL for this PR into the input field at the top and prees the "Preview" button
3. Verify that the fallback image appears in the preview card
4. (optional) Verify that the fallback image does not appear when testing current [production site](https://structuredcontent.live)
