### PR TITLE
Add heading and call to action to ticket tables

### DIFF
--- a/studio/schemas/sections/ticketsSection.ts
+++ b/studio/schemas/sections/ticketsSection.ts
@@ -9,6 +9,11 @@ export default {
       title: "Ticket table heading",
     },
     {
+      name: "callToAction",
+      type: "simpleCallToAction",
+      title: "Call to action",
+    },
+    {
       name: "type",
       type: "string",
       title: "Section type",

--- a/studio/schemas/sections/ticketsSection.ts
+++ b/studio/schemas/sections/ticketsSection.ts
@@ -4,6 +4,11 @@ export default {
   title: "Tickets section",
   fields: [
     {
+      name: "heading",
+      type: "string",
+      title: "Ticket table heading",
+    },
+    {
       name: "type",
       type: "string",
       title: "Section type",


### PR DESCRIPTION
# [PR title]

## Intent

Make it easier to add headings and call to actions to ticket tables

## Description

This adds a heading field and a simple call to action field to the tables section to the content model. 
