### PR TITLE
Hotfix for Speakers page Newsletter form

### DIFF
--- a/web/pages/speakers/[slug].tsx
+++ b/web/pages/speakers/[slug].tsx
@@ -3,14 +3,15 @@ import urlJoin from 'proper-url-join';
 import { groq } from 'next-sanity';
 import type { Person } from '../../types/Person';
 import type { Slug } from '../../types/Slug';
+import type { Session } from '../../types/Session';
+import type { Section } from "../../types/Section";
 import MetaTags from '../../components/MetaTags';
 import Nav from '../../components/Nav';
 import GridWrapper from '../../components/GridWrapper';
 import Footer from '../../components/Footer';
 import client from '../../lib/sanity.server';
-import { mainEventId } from '../../util/constants';
+import { mainEventId, newsletterSharedSectionId } from '../../util/constants';
 import TextBlock from '../../components/TextBlock';
-import ConferenceUpdatesForm from '../../components/ConferenceUpdatesForm';
 import Card from '../../components/Card';
 import HighlightedSpeakerBlock from '../../components/HighlightedSpeakerBlock';
 import SessionCard from '../../components/SessionCard';
@@ -20,7 +21,6 @@ import { SPEAKER } from '../../util/queries';
 import styles from '../app.module.css';
 import speakerStyles from './speakers.module.css';
 import { sessionStart } from '../../util/session';
-import { Session } from '../../types/Session';
 
 const QUERY = groq`
   {
@@ -33,6 +33,7 @@ const QUERY = groq`
         _id,
       }
     },
+    "newsletterSection": *[_id == "${newsletterSharedSectionId}"][0],
   }`;
 
 type SpeakerSession = {
@@ -63,6 +64,7 @@ interface SpeakersRouteProps {
         _id: string;
       }[];
     };
+    newsletterSection: Section;
   };
   slug: string;
 }
@@ -100,6 +102,7 @@ const SpeakersRoute = ({
     speaker: { bio, photo, name, pronouns, title, company, social, sessions },
     ticketsUrl,
     footer,
+    newsletterSection,
   },
   slug,
 }: SpeakersRouteProps) => (
@@ -179,16 +182,7 @@ const SpeakersRoute = ({
         </div>
       </GridWrapper>
     </main>
-    <ConferenceUpdatesForm
-      value={{
-        type: 'newsletter',
-        id: 'newsletter-form',
-        buttonText: 'Subscribe',
-      }}
-      index={0}
-      isInline={false}
-      renderNode={null}
-    />
+    <TextBlock value={newsletterSection} />
     <Footer links={footer.links} />
   </>
 );

--- a/web/util/constants.js
+++ b/web/util/constants.js
@@ -2,4 +2,5 @@
 module.exports = {
   mainEventId: 'aad77280-6394-4090-afad-1c0f2a0416c6',
   productionUrl: 'https://structuredcontent.live',
+  newsletterSharedSectionId: '469de653-12bf-4c31-9f48-25745ad9ddf5',
 };


### PR DESCRIPTION
# Hotfix for Speakers page Newsletter form

## Intent

Fixes the currently broken form at Speaker pages, e.g. https://structuredcontent.live/speakers/carrie-hane.
Solves [this](https://app.shortcut.com/sanity-io/story/17296/newsletter-module-not-working-on-speaker-details-page) Shortcut Story.

## Testing this PR

1. Open [the Preview Deploy for this PR for /speakers/carrie-hane](https://structured-content-2022-web-git-hotfix-speakers-page-con-d97c29.sanity.build/speakers/carrie-hane)
2. Scroll down to the bottom and verify that a "Get conference updates" form renders
3. Verify that unlike in current production, filling out an email address in the form and hitting the yellow :arrow_right: button actually sends you to a "success state" page
4. Verify that the "Newsletter" sharedSection has the same ID in both staging and production so that this fix actually will work when pushed to production