### PR TITLE
Hotfix for Navblock to once again render random shapes

### DIFF
--- a/web/components/NavBlock/FakeItem/FakeItem.tsx
+++ b/web/components/NavBlock/FakeItem/FakeItem.tsx
@@ -17,16 +17,20 @@ export const FakeItem = ({
   mobile,
   tablet,
   desktop,
-}: FakeItemProps) => (
-  <li
-    style={useAnimationProperties(true)}
-    className={clsx(
-      divider ? styles.divider : styles.fakeItem,
-      mobile && styles.mobile,
-      tablet && styles.tablet,
-      desktop && styles.desktop,
-      useRandomShape(RANDOM_SHAPE_PERCENT_CHANCE)
-    )}
-    aria-hidden="true"
-  />
-);
+}: FakeItemProps) => {
+  const randomShapeClass = useRandomShape(RANDOM_SHAPE_PERCENT_CHANCE);
+  const animationProperties = useAnimationProperties(true);
+  return (
+    <li
+      style={animationProperties}
+      className={clsx(
+        divider ? styles.divider : styles.fakeItem,
+        mobile && styles.mobile,
+        tablet && styles.tablet,
+        desktop && styles.desktop,
+        randomShapeClass
+      )}
+      aria-hidden="true"
+    />
+  );
+};

--- a/web/components/NavBlock/FakeItem/FakeItem.tsx
+++ b/web/components/NavBlock/FakeItem/FakeItem.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx';
 import { useAnimationProperties } from '../../../hooks/useAnimationProperties';
-import styles from '../NavBlock.module.css';
 import { useRandomShape } from '../../../hooks/useRandomShape';
+import styles from '../NavBlock.module.css';
 
 interface FakeItemProps {
   divider?: boolean;
@@ -19,15 +19,15 @@ export const FakeItem = ({
   desktop,
 }: FakeItemProps) => {
   const randomShapeClass = useRandomShape(RANDOM_SHAPE_PERCENT_CHANCE);
-  const animationProperties = useAnimationProperties(true);
   return (
     <li
-      style={animationProperties}
+      style={useAnimationProperties(true)}
       className={clsx(
         divider ? styles.divider : styles.fakeItem,
         mobile && styles.mobile,
         tablet && styles.tablet,
         desktop && styles.desktop,
+        !randomShapeClass && styles.noShape,
         randomShapeClass
       )}
       aria-hidden="true"

--- a/web/components/NavBlock/NavBlock.module.css
+++ b/web/components/NavBlock/NavBlock.module.css
@@ -50,9 +50,12 @@
 
 .fakeItem {
   flex: auto;
-  background: var(--color-brand-orange);
   border-radius: 8px;
   display: none;
+}
+
+.fakeItem.noShape {
+  background-color: var(--color-brand-orange);
 }
 
 .fakeItem.mobile {


### PR DESCRIPTION
# Hotfix for Navblock to once again render random shapes

## Intent

Restore the 33% chance to have a `<FakeItem />` render as a random "shape".

## Testing this PR

1. Open the [Preview Deploy for this PR](https://structured-content-2022-web-git-hotfix-navblock-render-shapes.sanity.build/)
2. Verify that the NavBlock once again renders "shapes" 