### PR TITLE
Render title & CTA for Registration Info, title for Tickets

### DIFF
--- a/web/components/Accordion/Accordion.module.css
+++ b/web/components/Accordion/Accordion.module.css
@@ -19,7 +19,7 @@
   border: none;
 }
 
-.heading {
+.sectionHeading {
   font: var(--font-display-xxs);
   margin: 0;
 }
@@ -53,11 +53,11 @@
     max-width: var(--max-body-text-width);
   }
 
-  .heading {
+  .sectionHeading {
     font: var(--font-display-xs);
   }
 
-  .heading,
+  .sectionHeading,
   .panel {
     margin-left: -52px;
     margin-right: -52px;
@@ -82,7 +82,7 @@
     margin: 128px auto;
   }
 
-  .heading,
+  .sectionHeading,
   .panel {
     margin-left: -64px;
     margin-right: -64px;

--- a/web/components/Accordion/Accordion.module.css
+++ b/web/components/Accordion/Accordion.module.css
@@ -1,7 +1,3 @@
-.container {
-  margin: 80px 0;
-}
-
 .accordion {
   display: block;
   width: 100%;
@@ -48,11 +44,6 @@
 }
 
 @media (--medium-up) {
-  .container {
-    margin: 96px auto;
-    max-width: var(--max-body-text-width);
-  }
-
   .sectionHeading {
     font: var(--font-display-xs);
   }
@@ -78,10 +69,6 @@
 }
 
 @media (--large-up) {
-  .container {
-    margin: 128px auto;
-  }
-
   .sectionHeading,
   .panel {
     margin-left: -64px;

--- a/web/components/Accordion/Accordion.tsx
+++ b/web/components/Accordion/Accordion.tsx
@@ -4,6 +4,7 @@ import styles from './Accordion.module.css';
 
 interface AccordionProps {
   baseId: string;
+  heading?: ReactNode;
   items: {
     title: string;
     content: ReactNode | ReactNode[];
@@ -21,7 +22,7 @@ const AccordionSection = ({ title, content, baseId }) => {
 
   return (
     <>
-      <h2 className={styles.heading} id={`heading-h2-${baseId}`}>
+      <h2 className={styles.sectionHeading} id={`heading-h2-${baseId}`}>
         <button
           onClick={onClick}
           className={clsx(styles.accordion, open && styles.active)}
@@ -38,8 +39,9 @@ const AccordionSection = ({ title, content, baseId }) => {
   );
 };
 
-export const Accordion = ({ baseId, items }: AccordionProps) => (
+export const Accordion = ({ baseId, items, heading }: AccordionProps) => (
   <div className={styles.container}>
+    {heading}
     {items.map(({ title, content }, index) => (
       <AccordionSection
         key={index}

--- a/web/components/Accordion/Accordion.tsx
+++ b/web/components/Accordion/Accordion.tsx
@@ -20,8 +20,8 @@ const AccordionSection = ({ title, content, baseId }) => {
   const panelId = `${baseId}-panel`;
 
   return (
-    <>
-      <h2 className={styles.sectionHeading} id={`heading-h2-${baseId}`}>
+    <section>
+      <h3 className={styles.sectionHeading} id={`heading-h2-${baseId}`}>
         <button
           onClick={onClick}
           className={clsx(styles.accordion, open && styles.active)}
@@ -30,11 +30,11 @@ const AccordionSection = ({ title, content, baseId }) => {
         >
           {title}
         </button>
-      </h2>
+      </h3>
       <div className={clsx(styles.panel, open && styles.open)} id={panelId}>
         {content}
       </div>
-    </>
+    </section>
   );
 };
 

--- a/web/components/Accordion/Accordion.tsx
+++ b/web/components/Accordion/Accordion.tsx
@@ -4,7 +4,6 @@ import styles from './Accordion.module.css';
 
 interface AccordionProps {
   baseId: string;
-  heading?: ReactNode;
   items: {
     title: string;
     content: ReactNode | ReactNode[];
@@ -39,9 +38,8 @@ const AccordionSection = ({ title, content, baseId }) => {
   );
 };
 
-export const Accordion = ({ baseId, items, heading }: AccordionProps) => (
-  <div className={styles.container}>
-    {heading}
+export const Accordion = ({ baseId, items }: AccordionProps) => (
+  <>
     {items.map(({ title, content }, index) => (
       <AccordionSection
         key={index}
@@ -50,5 +48,5 @@ export const Accordion = ({ baseId, items, heading }: AccordionProps) => (
         baseId={`${baseId}-${index}`}
       />
     ))}
-  </div>
+  </>
 );

--- a/web/components/TextBlock/Programs/Programs.module.css
+++ b/web/components/TextBlock/Programs/Programs.module.css
@@ -1,3 +1,7 @@
+.container {
+  margin: 80px 0;
+}
+
 .heading {
   max-width: var(--max-body-text-width);
   margin: 0 auto 32px;
@@ -31,6 +35,11 @@
 }
 
 @media (--medium-up) {
+  .container {
+    margin: 96px auto;
+    max-width: var(--max-body-text-width);
+  }
+
   .heading {
     margin-bottom: 48px;
   }
@@ -51,6 +60,10 @@
 }
 
 @media (--large-up) {
+  .container {
+    margin: 128px auto;
+  }
+
   .heading {
     margin-bottom: 64px;
   }

--- a/web/components/TextBlock/Programs/Programs.module.css
+++ b/web/components/TextBlock/Programs/Programs.module.css
@@ -3,8 +3,7 @@
 }
 
 .heading {
-  max-width: var(--max-body-text-width);
-  margin: 0 auto 32px;
+  margin: 0 0 32px;
 }
 
 .dayHeader {
@@ -41,7 +40,8 @@
   }
 
   .heading {
-    margin-bottom: 48px;
+    margin: 0 auto 48px;
+    max-width: var(--max-body-text-width);
   }
 
   .dayHeader {

--- a/web/components/TextBlock/Programs/Programs.module.css
+++ b/web/components/TextBlock/Programs/Programs.module.css
@@ -1,3 +1,8 @@
+.heading {
+  max-width: var(--max-body-text-width);
+  margin: 0 auto 32px;
+}
+
 .dayHeader {
   font: var(--font-body-small-bold);
   letter-spacing: var(--letter-spacing-body-small);
@@ -26,6 +31,10 @@
 }
 
 @media (--medium-up) {
+  .heading {
+    margin-bottom: 48px;
+  }
+
   .dayHeader {
     margin: 48px 0;
   }
@@ -38,5 +47,11 @@
 
   .sessionDuration {
     margin-bottom: 0;
+  }
+}
+
+@media (--large-up) {
+  .heading {
+    margin-bottom: 64px;
   }
 }

--- a/web/components/TextBlock/Programs/Programs.module.css
+++ b/web/components/TextBlock/Programs/Programs.module.css
@@ -40,8 +40,7 @@
   }
 
   .heading {
-    margin: 0 auto 48px;
-    max-width: var(--max-body-text-width);
+    margin-bottom: 48px;
   }
 
   .dayHeader {

--- a/web/components/TextBlock/Programs/Programs.tsx
+++ b/web/components/TextBlock/Programs/Programs.tsx
@@ -16,12 +16,13 @@ import styles from './Programs.module.css';
 
 type ProgramsProps = {
   type: EntitySectionSelection;
+  heading?: string;
   allPrograms: Program[];
   programs?: Program[];
 };
 
 export const Programs = ({
-  value: { type, allPrograms, programs },
+  value: { type, heading, allPrograms, programs },
   index,
 }: PortableTextComponentProps<ProgramsProps>) => {
   if (type === 'all' || type === 'highlighted') {
@@ -29,6 +30,7 @@ export const Programs = ({
       <GridWrapper>
         <Accordion
           baseId={`accordion-${index}`}
+          heading={heading && <h2 className={styles.heading}>{heading}</h2>}
           items={getCollectionForSelectionType(type, allPrograms, programs).map(
             (program) => {
               const firstVenue = program?.venues[0];

--- a/web/components/TextBlock/Programs/Programs.tsx
+++ b/web/components/TextBlock/Programs/Programs.tsx
@@ -28,11 +28,15 @@ export const Programs = ({
   if (type === 'all' || type === 'highlighted') {
     return (
       <GridWrapper>
-        <Accordion
-          baseId={`accordion-${index}`}
-          heading={heading && <h2 className={styles.heading}>{heading}</h2>}
-          items={getCollectionForSelectionType(type, allPrograms, programs).map(
-            (program) => {
+        <section className={styles.container}>
+          {heading && <h2 className={styles.heading}>{heading}</h2>}
+          <Accordion
+            baseId={`accordion-${index}`}
+            items={getCollectionForSelectionType(
+              type,
+              allPrograms,
+              programs
+            ).map((program) => {
               const firstVenue = program?.venues[0];
               const programName = firstVenue?.name || program.internalName;
               const timezone = firstVenue?.timezone || 'UTC';
@@ -94,9 +98,9 @@ export const Programs = ({
                   </div>
                 ),
               };
-            }
-          )}
-        />
+            })}
+          />
+        </section>
       </GridWrapper>
     );
   }

--- a/web/components/TextBlock/Tickets/Tickets.module.css
+++ b/web/components/TextBlock/Tickets/Tickets.module.css
@@ -1,6 +1,5 @@
 .heading {
-  max-width: var(--max-body-text-width);
-  margin: 0 auto 32px;
+  margin: 0 0 32px;
 }
 
 .table {
@@ -127,7 +126,8 @@
 
 @media (--medium-up) {
   .heading {
-    margin-bottom: 48px;
+    margin: 0 auto 48px;
+    max-width: var(--max-body-text-width);
   }
 
   .sections {

--- a/web/components/TextBlock/Tickets/Tickets.module.css
+++ b/web/components/TextBlock/Tickets/Tickets.module.css
@@ -123,8 +123,7 @@
 }
 
 .callToAction {
-  max-width: var(--max-body-text-width);
-  margin: 0 auto 32px;
+  margin-top: 32px;
 }
 
 @media (--medium-up) {
@@ -149,7 +148,8 @@
   }
 
   .callToAction {
-    margin-top: 48px;
+    margin: 48px auto 0;
+    max-width: var(--max-body-text-width);
   }
 }
 

--- a/web/components/TextBlock/Tickets/Tickets.module.css
+++ b/web/components/TextBlock/Tickets/Tickets.module.css
@@ -1,3 +1,7 @@
+.container {
+  margin: 80px 0;
+}
+
 .heading {
   margin: 0 0 32px;
 }
@@ -13,7 +17,6 @@
 .sections {
   font: var(--font-body-small-medium);
   letter-spacing: var(--letter-spacing-body-small);
-  margin: 48px 0;
 }
 
 .ticketInfo {
@@ -125,13 +128,13 @@
 }
 
 @media (--medium-up) {
+  .container {
+    margin: 96px 0;
+  }
+
   .heading {
     margin: 0 auto 48px;
     max-width: var(--max-body-text-width);
-  }
-
-  .sections {
-    margin: 64px 0;
   }
 
   .priceList {
@@ -151,6 +154,10 @@
 }
 
 @media (--large-up) {
+  .container {
+    margin: 128px 0;
+  }
+
   .heading {
     margin-bottom: 64px;
   }

--- a/web/components/TextBlock/Tickets/Tickets.module.css
+++ b/web/components/TextBlock/Tickets/Tickets.module.css
@@ -1,10 +1,15 @@
+.heading {
+  max-width: var(--max-body-text-width);
+  margin: 0 auto 32px;
+}
+
 .table {
   display: none;
   width: 100%;
   border-spacing: 8px;
   font: var(--font-body-small-medium);
   letter-spacing: var(--letter-spacing-body-small);
-  margin: 96px 0;
+  margin-bottom: 96px;
 }
 
 .sections {
@@ -117,6 +122,10 @@
 }
 
 @media (--medium-up) {
+  .heading {
+    margin-bottom: 48px;
+  }
+
   .sections {
     margin: 64px 0;
   }
@@ -134,6 +143,10 @@
 }
 
 @media (--large-up) {
+  .heading {
+    margin-bottom: 64px;
+  }
+
   .table {
     display: table;
   }

--- a/web/components/TextBlock/Tickets/Tickets.module.css
+++ b/web/components/TextBlock/Tickets/Tickets.module.css
@@ -9,7 +9,6 @@
   border-spacing: 8px;
   font: var(--font-body-small-medium);
   letter-spacing: var(--letter-spacing-body-small);
-  margin-bottom: 96px;
 }
 
 .sections {
@@ -121,6 +120,11 @@
   background-color: var(--color-brand-yellow-light);
 }
 
+.callToAction {
+  max-width: var(--max-body-text-width);
+  margin: 0 auto 32px;
+}
+
 @media (--medium-up) {
   .heading {
     margin-bottom: 48px;
@@ -139,6 +143,10 @@
   .group {
     margin-top: 0;
     flex-basis: calc(50% - 4px);
+  }
+
+  .callToAction {
+    margin-top: 48px;
   }
 }
 
@@ -161,5 +169,9 @@
 
   .group {
     margin-top: 8px;
+  }
+
+  .callToAction {
+    margin-top: 64px;
   }
 }

--- a/web/components/TextBlock/Tickets/Tickets.tsx
+++ b/web/components/TextBlock/Tickets/Tickets.tsx
@@ -5,17 +5,20 @@ import sub from 'date-fns/sub';
 import { format } from 'date-fns-tz';
 import { PortableText, PortableTextComponentProps } from '@portabletext/react';
 import { Fragment } from 'react';
-import { Ticket, TicketGroup } from '../../../types/Ticket';
-import { EntitySectionSelection } from '../../../types/EntitySectionSelection';
+import type { SimpleCallToAction } from '../../../types/SimpleCallToAction';
+import type { Ticket, TicketGroup } from '../../../types/Ticket';
+import type { EntitySectionSelection } from '../../../types/EntitySectionSelection';
 import { getCollectionForSelectionType } from '../../../util/entity';
 import GridWrapper from '../../GridWrapper';
 import FeatureCheckmark from '../../FeatureCheckmark';
 import FeatureSection from '../../FeatureSection';
 import styles from './Tickets.module.css';
+import ButtonLink from '../../ButtonLink';
 
 interface TicketsProps {
   type: EntitySectionSelection;
   heading: string;
+  callToAction?: SimpleCallToAction;
   allTickets: Ticket[];
   tickets?: Ticket[];
 }
@@ -101,7 +104,7 @@ const priceList = (ticket: Ticket) => (
 );
 
 export const Tickets = ({
-  value: { type, heading, tickets, allTickets },
+  value: { type, heading, callToAction, tickets, allTickets },
 }: PortableTextComponentProps<TicketsProps>) => {
   if (!Array.isArray(allTickets) || allTickets.length === 0) {
     console.error(`Tickets missing or invalid tickets array: '${allTickets}'`);
@@ -189,6 +192,18 @@ export const Tickets = ({
           )
         )}
       </div>
+
+      {callToAction && (
+        <div className={styles.callToAction}>
+          <ButtonLink
+            url={
+              callToAction.link?.external ||
+              callToAction.link?.internal?.slug?.current
+            }
+            text={callToAction.text}
+          />
+        </div>
+      )}
     </GridWrapper>
   );
 };

--- a/web/components/TextBlock/Tickets/Tickets.tsx
+++ b/web/components/TextBlock/Tickets/Tickets.tsx
@@ -127,83 +127,89 @@ export const Tickets = ({
 
   return (
     <GridWrapper>
-      {heading && <h2 className={styles.heading}>{heading}</h2>}
-      <table className={styles.table}>
-        <thead>
-          <tr>
-            <th />
-            {getCollectionForSelectionType(type, allTickets, tickets).map(
-              (ticket) => (
-                <th key={ticket._id} scope="col" className={styles.ticketInfo}>
-                  <strong className={styles.name}>{ticket.type}</strong>
+      <section className={styles.container}>
+        {heading && <h2 className={styles.heading}>{heading}</h2>}
+        <table className={styles.table}>
+          <thead>
+            <tr>
+              <th />
+              {getCollectionForSelectionType(type, allTickets, tickets).map(
+                (ticket) => (
+                  <th
+                    key={ticket._id}
+                    scope="col"
+                    className={styles.ticketInfo}
+                  >
+                    <strong className={styles.name}>{ticket.type}</strong>
+                    {ticket.description && (
+                      <div className={styles.description}>
+                        <PortableText value={ticket.description} />
+                      </div>
+                    )}
+                    {priceList(ticket)}
+                  </th>
+                )
+              )}
+            </tr>
+          </thead>
+          <tbody>
+            {includedTypes.map((includedType) => (
+              <tr key={includedType}>
+                <th className={styles.feature} scope="row">
+                  {includedType}
+                </th>
+                {getCollectionForSelectionType(type, allTickets, tickets).map(
+                  (ticket) => {
+                    const featureIncluded =
+                      ticket.included.includes(includedType);
+                    return (
+                      <td
+                        key={ticket._id}
+                        className={clsx(
+                          styles.featurePresence,
+                          featureIncluded && styles.featureIncluded
+                        )}
+                      >
+                        <FeatureCheckmark included={featureIncluded} />
+                      </td>
+                    );
+                  }
+                )}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+
+        <div className={styles.sections}>
+          {getCollectionForSelectionType(type, allTickets, tickets).map(
+            (ticket) => (
+              <FeatureSection features={ticket.included} key={ticket._id}>
+                <>
+                  <h3 className={styles.name}>{ticket.type}</h3>
                   {ticket.description && (
                     <div className={styles.description}>
                       <PortableText value={ticket.description} />
                     </div>
                   )}
                   {priceList(ticket)}
-                </th>
-              )
-            )}
-          </tr>
-        </thead>
-        <tbody>
-          {includedTypes.map((includedType) => (
-            <tr key={includedType}>
-              <th className={styles.feature} scope="row">
-                {includedType}
-              </th>
-              {getCollectionForSelectionType(type, allTickets, tickets).map(
-                (ticket) => {
-                  const featureIncluded =
-                    ticket.included.includes(includedType);
-                  return (
-                    <td
-                      key={ticket._id}
-                      className={clsx(
-                        styles.featurePresence,
-                        featureIncluded && styles.featureIncluded
-                      )}
-                    >
-                      <FeatureCheckmark included={featureIncluded} />
-                    </td>
-                  );
-                }
-              )}
-            </tr>
-          ))}
-        </tbody>
-      </table>
-
-      <div className={styles.sections}>
-        {getCollectionForSelectionType(type, allTickets, tickets).map(
-          (ticket) => (
-            <FeatureSection features={ticket.included} key={ticket._id}>
-              <>
-                <h3 className={styles.name}>{ticket.type}</h3>
-                {ticket.description && (
-                  <div className={styles.description}>
-                    <PortableText value={ticket.description} />
-                  </div>
-                )}
-                {priceList(ticket)}
-              </>
-            </FeatureSection>
-          )
-        )}
-      </div>
-
-      {callToAction && (
-        <div className={styles.callToAction}>
-          <ButtonLink
-            url={
-              callToAction.link?.external ||
-              callToAction.link?.internal?.slug?.current
-            }
-            text={callToAction.text}
-          />
+                </>
+              </FeatureSection>
+            )
+          )}
         </div>
-      )}
+
+        {callToAction && (
+          <div className={styles.callToAction}>
+            <ButtonLink
+              url={
+                callToAction.link?.external ||
+                callToAction.link?.internal?.slug?.current
+              }
+              text={callToAction.text}
+            />
+          </div>
+        )}
+      </section>
     </GridWrapper>
   );
 };

--- a/web/components/TextBlock/Tickets/Tickets.tsx
+++ b/web/components/TextBlock/Tickets/Tickets.tsx
@@ -6,15 +6,16 @@ import { format } from 'date-fns-tz';
 import { PortableText, PortableTextComponentProps } from '@portabletext/react';
 import { Fragment } from 'react';
 import { Ticket, TicketGroup } from '../../../types/Ticket';
-import GridWrapper from '../../GridWrapper';
 import { EntitySectionSelection } from '../../../types/EntitySectionSelection';
-import styles from './Tickets.module.css';
 import { getCollectionForSelectionType } from '../../../util/entity';
+import GridWrapper from '../../GridWrapper';
 import FeatureCheckmark from '../../FeatureCheckmark';
 import FeatureSection from '../../FeatureSection';
+import styles from './Tickets.module.css';
 
 interface TicketsProps {
   type: EntitySectionSelection;
+  heading: string;
   allTickets: Ticket[];
   tickets?: Ticket[];
 }
@@ -100,7 +101,7 @@ const priceList = (ticket: Ticket) => (
 );
 
 export const Tickets = ({
-  value: { type, tickets, allTickets },
+  value: { type, heading, tickets, allTickets },
 }: PortableTextComponentProps<TicketsProps>) => {
   if (!Array.isArray(allTickets) || allTickets.length === 0) {
     console.error(`Tickets missing or invalid tickets array: '${allTickets}'`);
@@ -123,6 +124,7 @@ export const Tickets = ({
 
   return (
     <GridWrapper>
+      {heading && <h2 className={styles.heading}>{heading}</h2>}
       <table className={styles.table}>
         <thead>
           <tr>

--- a/web/components/TextBlock/Tickets/Tickets.tsx
+++ b/web/components/TextBlock/Tickets/Tickets.tsx
@@ -5,20 +5,20 @@ import sub from 'date-fns/sub';
 import { format } from 'date-fns-tz';
 import { PortableText, PortableTextComponentProps } from '@portabletext/react';
 import { Fragment } from 'react';
-import type { SimpleCallToAction } from '../../../types/SimpleCallToAction';
+import type { SimpleCallToAction as TSimpleCallToAction } from '../../../types/SimpleCallToAction';
 import type { Ticket, TicketGroup } from '../../../types/Ticket';
 import type { EntitySectionSelection } from '../../../types/EntitySectionSelection';
 import { getCollectionForSelectionType } from '../../../util/entity';
 import GridWrapper from '../../GridWrapper';
 import FeatureCheckmark from '../../FeatureCheckmark';
 import FeatureSection from '../../FeatureSection';
+import SimpleCallToAction from '../../SimpleCallToAction';
 import styles from './Tickets.module.css';
-import ButtonLink from '../../ButtonLink';
 
 interface TicketsProps {
   type: EntitySectionSelection;
   heading: string;
-  callToAction?: SimpleCallToAction;
+  callToAction?: TSimpleCallToAction;
   allTickets: Ticket[];
   tickets?: Ticket[];
 }
@@ -200,13 +200,7 @@ export const Tickets = ({
 
         {callToAction && (
           <div className={styles.callToAction}>
-            <ButtonLink
-              url={
-                callToAction.link?.external ||
-                callToAction.link?.internal?.slug?.current
-              }
-              text={callToAction.text}
-            />
+            <SimpleCallToAction {...callToAction} />
           </div>
         )}
       </section>

--- a/web/pages/[[...slug]].tsx
+++ b/web/pages/[[...slug]].tsx
@@ -70,6 +70,7 @@ const SHARED_SECTIONS = `
   _type == "formSection" => { ... },
   _type == "programsSection" => {
     type,
+    heading,
     programs[]-> { ${PROGRAM} },
     "allPrograms": *[_type == "program"] { ${PROGRAM} }
   },

--- a/web/pages/[[...slug]].tsx
+++ b/web/pages/[[...slug]].tsx
@@ -64,6 +64,7 @@ const SHARED_SECTIONS = `
   },
   _type == "ticketsSection" => {
     type,
+    heading,
     tickets[]->{ ${TICKET} },
     "allTickets": *[_id == "${mainEventId}"][0].tickets[]->{ ${TICKET} }
   },

--- a/web/pages/[[...slug]].tsx
+++ b/web/pages/[[...slug]].tsx
@@ -24,6 +24,7 @@ import {
   HERO,
   PROGRAM,
   QUESTION_AND_ANSWER_COLLECTION_SECTION,
+  SIMPLE_CALL_TO_ACTION,
   SPONSORSHIP,
   TEXT_AND_IMAGE_SECTION,
   TICKET,
@@ -65,6 +66,7 @@ const SHARED_SECTIONS = `
   _type == "ticketsSection" => {
     type,
     heading,
+    callToAction { ${SIMPLE_CALL_TO_ACTION} },
     tickets[]->{ ${TICKET} },
     "allTickets": *[_id == "${mainEventId}"][0].tickets[]->{ ${TICKET} }
   },

--- a/web/pages/speakers/[slug].tsx
+++ b/web/pages/speakers/[slug].tsx
@@ -4,7 +4,7 @@ import { groq } from 'next-sanity';
 import type { Person } from '../../types/Person';
 import type { Slug } from '../../types/Slug';
 import type { Session } from '../../types/Session';
-import type { Section } from "../../types/Section";
+import type { Section } from '../../types/Section';
 import MetaTags from '../../components/MetaTags';
 import Nav from '../../components/Nav';
 import GridWrapper from '../../components/GridWrapper';


### PR DESCRIPTION
# Render title & CTA for Registration Info, title for Tickets

## Intent

Solves [this](https://app.shortcut.com/sanity-io/story/15932/programs-section-tickets-section-add-title-field-in-studio) Shortcut Story.

## Description

Implements the requested changes in accordance with somewhat updated Figma sketches. The Program sketch is not completely up-to-date with latest specs; the paragraph under the "Ticket details" header should not be present in the sketches. (See [this](https://wja.slack.com/archives/C02E2ERKR7E/p1649060350131819) Slack thread.)

## Testing this PR

1. Verify that the "Programs: section heading" heading above the programs table in [/program](https://structured-content-2022-web-git-render-title-and-cta-for-a2e95a.sanity.build/program) renders in accordance to the Figma sketches
2. Verify that the "Ticket details" heading above the tickets table and the "Get tickets now" button below the table in [/registration-info](https://structured-content-2022-web-git-render-title-and-cta-for-a2e95a.sanity.build/registration-info) renders in accordance to the Figma sketches