### PR TITLE
Speaker section

### DIFF
--- a/web/components/TextBlock/Speakers/Speakers.module.css
+++ b/web/components/TextBlock/Speakers/Speakers.module.css
@@ -22,12 +22,35 @@
 
 .speakerItem {
   border-bottom: 2px solid var(--color-brand-black);
-  display: flex;
-  align-items: center;
 }
 
 .speakerItem:first-child {
   border-top: 2px solid var(--color-brand-black);
+}
+
+.speakerLink {
+  text-decoration: none;
+  display: flex;
+  align-items: center;
+  margin: 0 -16px;
+  padding: 0 16px;
+  border-radius: 16px;
+}
+
+.speakerLink:hover {
+  background: var(--color-brand-orange);
+}
+
+.speakerLink:active {
+  background: var(--color-brand-yellow);
+}
+
+.speakerLink::after {
+  content: '->';
+  white-space: nowrap;
+  letter-spacing: normal; /* Chromium disables ligatures otherwise */
+  flex: auto;
+  text-align: right;
 }
 
 .speakerPhoto {
@@ -74,6 +97,16 @@
 
   .heading {
     font: var(--font-display-lg);
+  }
+
+  .speakerLink {
+    margin: 0 -32px;
+    padding: 0 32px;
+  }
+
+  .speakerLink::after {
+    font-size: 40px;
+    line-height: 1;
   }
 
   .speakerPhoto {

--- a/web/components/TextBlock/Speakers/Speakers.module.css
+++ b/web/components/TextBlock/Speakers/Speakers.module.css
@@ -1,0 +1,92 @@
+.container {
+  padding: 80px 0;
+  background: var(--color-brand-yellow-light);
+}
+
+.introContent {
+  text-align: center;
+  margin-bottom: 48px;
+}
+
+.heading {
+  margin: 0 0 24px;
+  font: var(--font-display-sm);
+}
+
+.speakerList {
+  margin: 0 auto;
+  padding: 0;
+  list-style: none;
+  max-width: 1062px;
+}
+
+.speakerItem {
+  border-bottom: 2px solid var(--color-brand-black);
+  display: flex;
+  align-items: center;
+}
+
+.speakerItem:first-child {
+  border-top: 2px solid var(--color-brand-black);
+}
+
+.speakerPhoto {
+  margin: 16px 24px 16px 0;
+  border-radius: 16px;
+  width: 64px;
+  height: auto;
+}
+
+.speakerDetails {
+  margin: 24px 0;
+  font: var(--font-body-base-medium);
+}
+
+.speakerName {
+  font: var(--font-display-xxs);
+  letter-spacing: normal;
+  display: block;
+  margin-bottom: 8px;
+}
+
+@media (--medium-up) {
+  .container {
+    padding: 96px 0;
+  }
+
+  .introContent {
+    margin-bottom: 64px;
+  }
+
+  .heading {
+    margin-bottom: 32px;
+  }
+
+  .speakerName {
+    font: var(--font-display-xs);
+  }
+}
+
+@media (--large-up) {
+  .container {
+    padding: 128px 0;
+  }
+
+  .heading {
+    font: var(--font-display-lg);
+  }
+
+  .speakerPhoto {
+    margin: 31px 48px 32px 0;
+    width: 193px;
+  }
+
+  .speakerDetails {
+    margin: 80px 0;
+    font: var(--font-body-large-medium);
+  }
+
+  .speakerName {
+    font: var(--font-display-base);
+  }
+}

--- a/web/components/TextBlock/Speakers/Speakers.tsx
+++ b/web/components/TextBlock/Speakers/Speakers.tsx
@@ -1,18 +1,34 @@
-import { Person } from '../../../types/Person';
-import { PortableTextComponentProps } from '@portabletext/react/dist/react-portable-text.esm';
-import { EntitySectionSelection } from '../../../types/EntitySectionSelection';
+import type { PortableTextComponentProps } from '@portabletext/react';
+import type { EntitySectionSelection } from '../../../types/EntitySectionSelection';
+import type { Person } from '../../../types/Person';
+import type { SimpleCallToAction } from '../../../types/SimpleCallToAction';
 import { getCollectionForSelectionType } from '../../../util/entity';
+import ButtonLink from '../../ButtonLink';
 
 type SpeakersProps = {
   type: EntitySectionSelection;
+  heading?: string;
+  callToAction?: SimpleCallToAction;
   allSpeakers?: Person[];
   speakers?: Person[];
 };
 
 export const Speakers = ({
-  value: { type, allSpeakers, speakers },
+  value: { type, heading, callToAction, allSpeakers, speakers },
 }: PortableTextComponentProps<SpeakersProps>) => (
   <>
+    {heading && <h2>{heading}</h2>}
+    {callToAction && (
+      <div>
+        <ButtonLink
+          url={
+            callToAction.link?.external ||
+            callToAction.link?.internal?.slug?.current
+          }
+          text={callToAction.text}
+        />
+      </div>
+    )}
     {getCollectionForSelectionType(type, allSpeakers, speakers).map(
       (speaker) => (
         <div key={speaker._id}>

--- a/web/components/TextBlock/Speakers/Speakers.tsx
+++ b/web/components/TextBlock/Speakers/Speakers.tsx
@@ -5,6 +5,8 @@ import type { Person } from '../../../types/Person';
 import type { SimpleCallToAction } from '../../../types/SimpleCallToAction';
 import { getCollectionForSelectionType } from '../../../util/entity';
 import ButtonLink from '../../ButtonLink';
+import GridWrapper from '../../GridWrapper';
+import styles from './Speakers.module.css';
 
 type SpeakersProps = {
   type: EntitySectionSelection;
@@ -17,40 +19,47 @@ type SpeakersProps = {
 export const Speakers = ({
   value: { type, heading, callToAction, allSpeakers, speakers },
 }: PortableTextComponentProps<SpeakersProps>) => (
-  <>
-    {heading && <h2>{heading}</h2>}
-    {callToAction && (
-      <div>
-        <ButtonLink
-          url={
-            callToAction.link?.external ||
-            callToAction.link?.internal?.slug?.current
-          }
-          text={callToAction.text}
-        />
+  <section className={styles.container}>
+    <GridWrapper>
+      <div className={styles.introContent}>
+        {heading && <h2 className={styles.heading}>{heading}</h2>}
+        {callToAction && (
+          <ButtonLink
+            url={
+              callToAction.link?.external ||
+              callToAction.link?.internal?.slug?.current
+            }
+            text={callToAction.text}
+          />
+        )}
       </div>
-    )}
-    {getCollectionForSelectionType(type, allSpeakers, speakers).map(
-      (speaker) => (
-        <div key={speaker._id}>
-          {speaker.photo && (
-            /* eslint-disable-next-line @next/next/no-img-element */
-            <img
-              src={imageUrlFor(speaker.photo)
-                .size(193, 243)
-                .saturation(-100)
-                .url()}
-              alt={speaker.photo.alt || ''}
-              width={193}
-              height={243}
-            />
-          )}
-          <div>{speaker.name}</div>
-          <div>
-            {[speaker.title, speaker.company].filter(Boolean).join(', ')}
-          </div>
-        </div>
-      )
-    )}
-  </>
+      <ul className={styles.speakerList}>
+        {getCollectionForSelectionType(type, allSpeakers, speakers).map(
+          (speaker) => (
+            <li key={speaker._id} className={styles.speakerItem}>
+              {speaker.photo && (
+                /* eslint-disable-next-line @next/next/no-img-element */
+                <img
+                  src={imageUrlFor(speaker.photo)
+                    .size(193, 243)
+                    .saturation(-100)
+                    .url()}
+                  alt={speaker.photo.alt || ''}
+                  width={193}
+                  height={243}
+                  className={styles.speakerPhoto}
+                />
+              )}
+              <div className={styles.speakerDetails}>
+                <strong className={styles.speakerName}>{speaker.name}</strong>
+                <div>
+                  {[speaker.title, speaker.company].filter(Boolean).join(', ')}
+                </div>
+              </div>
+            </li>
+          )
+        )}
+      </ul>
+    </GridWrapper>
+  </section>
 );

--- a/web/components/TextBlock/Speakers/Speakers.tsx
+++ b/web/components/TextBlock/Speakers/Speakers.tsx
@@ -33,7 +33,9 @@ export const Speakers = ({
       (speaker) => (
         <div key={speaker._id}>
           <div>{speaker.name}</div>
-          <div>{speaker.title}</div>
+          <div>
+            {[speaker.title, speaker.company].filter(Boolean).join(', ')}
+          </div>
         </div>
       )
     )}

--- a/web/components/TextBlock/Speakers/Speakers.tsx
+++ b/web/components/TextBlock/Speakers/Speakers.tsx
@@ -1,9 +1,11 @@
 import type { PortableTextComponentProps } from '@portabletext/react';
+import Link from 'next/link';
 import { imageUrlFor } from '../../../lib/sanity';
 import type { EntitySectionSelection } from '../../../types/EntitySectionSelection';
 import type { Person } from '../../../types/Person';
 import type { SimpleCallToAction } from '../../../types/SimpleCallToAction';
 import { getCollectionForSelectionType } from '../../../util/entity';
+import { getEntityPath } from '../../../util/entityPaths';
 import ButtonLink from '../../ButtonLink';
 import GridWrapper from '../../GridWrapper';
 import styles from './Speakers.module.css';
@@ -37,25 +39,33 @@ export const Speakers = ({
         {getCollectionForSelectionType(type, allSpeakers, speakers).map(
           (speaker) => (
             <li key={speaker._id} className={styles.speakerItem}>
-              {speaker.photo && (
-                /* eslint-disable-next-line @next/next/no-img-element */
-                <img
-                  src={imageUrlFor(speaker.photo)
-                    .size(193, 243)
-                    .saturation(-100)
-                    .url()}
-                  alt={speaker.photo.alt || ''}
-                  width={193}
-                  height={243}
-                  className={styles.speakerPhoto}
-                />
-              )}
-              <div className={styles.speakerDetails}>
-                <strong className={styles.speakerName}>{speaker.name}</strong>
-                <div>
-                  {[speaker.title, speaker.company].filter(Boolean).join(', ')}
-                </div>
-              </div>
+              <Link href={getEntityPath(speaker)}>
+                <a className={styles.speakerLink}>
+                  {speaker.photo && (
+                    /* eslint-disable-next-line @next/next/no-img-element */
+                    <img
+                      src={imageUrlFor(speaker.photo)
+                        .size(193, 243)
+                        .saturation(-100)
+                        .url()}
+                      alt={speaker.photo.alt || ''}
+                      width={193}
+                      height={243}
+                      className={styles.speakerPhoto}
+                    />
+                  )}
+                  <div className={styles.speakerDetails}>
+                    <strong className={styles.speakerName}>
+                      {speaker.name}
+                    </strong>
+                    <div>
+                      {[speaker.title, speaker.company]
+                        .filter(Boolean)
+                        .join(', ')}
+                    </div>
+                  </div>
+                </a>
+              </Link>
             </li>
           )
         )}

--- a/web/components/TextBlock/Speakers/Speakers.tsx
+++ b/web/components/TextBlock/Speakers/Speakers.tsx
@@ -3,17 +3,17 @@ import Link from 'next/link';
 import { imageUrlFor } from '../../../lib/sanity';
 import type { EntitySectionSelection } from '../../../types/EntitySectionSelection';
 import type { Person } from '../../../types/Person';
-import type { SimpleCallToAction } from '../../../types/SimpleCallToAction';
+import type { SimpleCallToAction as TSimpleCallToAction } from '../../../types/SimpleCallToAction';
 import { getCollectionForSelectionType } from '../../../util/entity';
 import { getEntityPath } from '../../../util/entityPaths';
-import ButtonLink from '../../ButtonLink';
 import GridWrapper from '../../GridWrapper';
+import SimpleCallToAction from '../../SimpleCallToAction';
 import styles from './Speakers.module.css';
 
 type SpeakersProps = {
   type: EntitySectionSelection;
   heading?: string;
-  callToAction?: SimpleCallToAction;
+  callToAction?: TSimpleCallToAction;
   allSpeakers?: Person[];
   speakers?: Person[];
 };
@@ -25,15 +25,7 @@ export const Speakers = ({
     <GridWrapper>
       <div className={styles.introContent}>
         {heading && <h2 className={styles.heading}>{heading}</h2>}
-        {callToAction && (
-          <ButtonLink
-            url={
-              callToAction.link?.external ||
-              callToAction.link?.internal?.slug?.current
-            }
-            text={callToAction.text}
-          />
-        )}
+        <SimpleCallToAction {...callToAction} />
       </div>
       <ul className={styles.speakerList}>
         {getCollectionForSelectionType(type, allSpeakers, speakers).map(

--- a/web/components/TextBlock/Speakers/Speakers.tsx
+++ b/web/components/TextBlock/Speakers/Speakers.tsx
@@ -1,4 +1,5 @@
 import type { PortableTextComponentProps } from '@portabletext/react';
+import { imageUrlFor } from '../../../lib/sanity';
 import type { EntitySectionSelection } from '../../../types/EntitySectionSelection';
 import type { Person } from '../../../types/Person';
 import type { SimpleCallToAction } from '../../../types/SimpleCallToAction';
@@ -32,6 +33,18 @@ export const Speakers = ({
     {getCollectionForSelectionType(type, allSpeakers, speakers).map(
       (speaker) => (
         <div key={speaker._id}>
+          {speaker.photo && (
+            /* eslint-disable-next-line @next/next/no-img-element */
+            <img
+              src={imageUrlFor(speaker.photo)
+                .size(193, 243)
+                .saturation(-100)
+                .url()}
+              alt={speaker.photo.alt || ''}
+              width={193}
+              height={243}
+            />
+          )}
           <div>{speaker.name}</div>
           <div>
             {[speaker.title, speaker.company].filter(Boolean).join(', ')}

--- a/web/components/TextBlock/Speakers/Speakers.tsx
+++ b/web/components/TextBlock/Speakers/Speakers.tsx
@@ -2,7 +2,7 @@ import type { PortableTextComponentProps } from '@portabletext/react';
 import Link from 'next/link';
 import { imageUrlFor } from '../../../lib/sanity';
 import type { EntitySectionSelection } from '../../../types/EntitySectionSelection';
-import type { Person } from '../../../types/Person';
+import type { FrontpagePerson } from '../../../types/Person';
 import type { SimpleCallToAction as TSimpleCallToAction } from '../../../types/SimpleCallToAction';
 import { getCollectionForSelectionType } from '../../../util/entity';
 import { getEntityPath } from '../../../util/entityPaths';
@@ -14,8 +14,8 @@ type SpeakersProps = {
   type: EntitySectionSelection;
   heading?: string;
   callToAction?: TSimpleCallToAction;
-  allSpeakers?: Person[];
-  speakers?: Person[];
+  allSpeakers?: FrontpagePerson[];
+  speakers?: FrontpagePerson[];
 };
 
 export const Speakers = ({

--- a/web/components/TextBlock/TextBlock/TextBlock.tsx
+++ b/web/components/TextBlock/TextBlock/TextBlock.tsx
@@ -17,6 +17,7 @@ import Tickets from '../Tickets';
 import Figure from '../Figure';
 import Sponsorships from '../Sponsorships';
 import Programs from '../Programs';
+import Speakers from '../Speakers';
 
 const components: Partial<PortableTextComponents> = {
   types: {
@@ -32,6 +33,7 @@ const components: Partial<PortableTextComponents> = {
     venuesSection: VenuesSection,
     sponsorsSection: SponsorsSection,
     sponsorshipsSection: Sponsorships,
+    speakersSection: Speakers,
     ticketsSection: Tickets,
     figure: Figure,
     programsSection: Programs,

--- a/web/pages/[[...slug]].tsx
+++ b/web/pages/[[...slug]].tsx
@@ -25,6 +25,7 @@ import {
   PROGRAM,
   QUESTION_AND_ANSWER_COLLECTION_SECTION,
   SIMPLE_CALL_TO_ACTION,
+  SPEAKER_FRONTPAGE,
   SPONSORSHIP,
   TEXT_AND_IMAGE_SECTION,
   TICKET,
@@ -43,8 +44,8 @@ const SHARED_SECTIONS = `
     ...,
     heading,
     callToAction { ${SIMPLE_CALL_TO_ACTION} }, 
-    speakers[]->,
-    "allSpeakers": *[_type == "person"],
+    speakers[]-> { ${SPEAKER_FRONTPAGE} },
+    "allSpeakers": *[_type == "person"] { ${SPEAKER_FRONTPAGE} },
   },
   _type == "sessionsSection" => {
     ...,

--- a/web/pages/[[...slug]].tsx
+++ b/web/pages/[[...slug]].tsx
@@ -24,6 +24,7 @@ import {
   HERO,
   PROGRAM,
   QUESTION_AND_ANSWER_COLLECTION_SECTION,
+  SIMPLE_CALL_TO_ACTION,
   SPONSORSHIP,
   TEXT_AND_IMAGE_SECTION,
   TICKET,
@@ -40,6 +41,8 @@ const SHARED_SECTIONS = `
   },
   _type == "speakersSection" => {
     ...,
+    heading,
+    callToAction { ${SIMPLE_CALL_TO_ACTION} }, 
     speakers[]->,
     "allSpeakers": *[_type == "person"],
   },

--- a/web/pages/speakers/[slug].tsx
+++ b/web/pages/speakers/[slug].tsx
@@ -4,7 +4,7 @@ import { groq } from 'next-sanity';
 import type { Person } from '../../types/Person';
 import type { Slug } from '../../types/Slug';
 import type { Session } from '../../types/Session';
-import type { Section } from "../../types/Section";
+import type { Section } from '../../types/Section';
 import MetaTags from '../../components/MetaTags';
 import Nav from '../../components/Nav';
 import GridWrapper from '../../components/GridWrapper';

--- a/web/types/Person.ts
+++ b/web/types/Person.ts
@@ -20,3 +20,13 @@ export type Person = {
   _type: 'person';
   _updatedAt: string;
 };
+
+export type FrontpagePerson = {
+  _id: string;
+  _type: 'person';
+  slug: Slug;
+  photo: Figure;
+  name: string;
+  title: string;
+  company: string;
+};

--- a/web/util/entityPaths.ts
+++ b/web/util/entityPaths.ts
@@ -14,6 +14,8 @@ export const getEntityPath = (entity?: { _type: string; slug?: Slug }) => {
       return urlJoin(entity.slug.current, { leadingSlash: true });
     case 'article':
       return urlJoin('article', entity.slug.current, { leadingSlash: true });
+    case 'person':
+      return urlJoin('speakers', entity.slug.current, { leadingSlash: true });
     default:
       console.error(
         `getEntityPath: unsupported entity type: '${entity._type}'`

--- a/web/util/queries.ts
+++ b/web/util/queries.ts
@@ -80,6 +80,16 @@ const SPEAKER = `
   },       
 `;
 
+const SPEAKER_FRONTPAGE = `
+  _id,
+  _type, 
+  slug,
+  photo { ${FIGURE} },
+  name,
+  title,
+  company,
+`;
+
 const SPONSORSHIP = `
   _createdAt,
   _id,
@@ -117,4 +127,5 @@ export {
   TICKET,
   SPONSORSHIP,
   SPEAKER,
+  SPEAKER_FRONTPAGE,
 };


### PR DESCRIPTION
# Speaker section

## Intent

Solve the app portion of Shortcut story [Speakers section (to enable featured speakers on home page)](https://app.shortcut.com/sanity-io/story/17463/speakers-section-to-enable-featured-speakers-on-home-page)

## Description

The styling is based on the "Desktop/Homepage V3" sketch in Figma along with "Speaker Card" in Figma's "Website (For review)" section. For mobile/tablet it's basically just made up, due to lack of sketches.

There has been some uncertainty regarding the background color, but as discussed in standup today the planned order of blocks apparently means yellow background works out. See [Carrie's comment in a different story regarding the front page](https://app.shortcut.com/sanity-io/story/17239/possible-design-adjustments-to-home-page-and-programs-location-page#activity-17495).

It's possible the speaker list might be split out into a "SpeakerList" component to be shared with the upcoming session details page (although there are some differences in appearance, so it's not clear), but due to time pressure all such considerations have been postponed to the [session details PR](https://github.com/sanity-io/structured-content-2022/pull/134) (which is prioritized lower).

## Testing this PR

1. Open https://structured-content-2022-web-git-speaker-section.sanity.build/
2. Scroll down below the "Become a sponsor" button, verify that a "Featured Speakers" section appears and looks/behaves OK