### PR TITLE
make items optional

### DIFF
--- a/web/components/Nav/Nav.tsx
+++ b/web/components/Nav/Nav.tsx
@@ -13,14 +13,14 @@ interface NavProps {
   onFrontPage?: boolean;
   currentPath: string;
   ticketsUrl: string;
-  items: PrimaryNavItem[];
+  items?: PrimaryNavItem[];
 }
 
 export const Nav = ({
   onFrontPage,
   currentPath,
   ticketsUrl,
-  items,
+  items = [],
 }: NavProps) => {
   const [menuOpened, setMenuOpened] = useState(false);
   const contentsId = 'nav-menu-contents';
@@ -78,19 +78,20 @@ export const Nav = ({
               Tickets
             </MenuItem>
 
-            {items.map(
-              ({ label, target: { external, internal, blank } }, index) => (
-                <MenuItem
-                  key={index}
-                  {...{ closeMenu, currentPath }}
-                  href={external || getEntityPath(internal)}
-                  {...(blank && { target: '_blank', rel: 'noreferrer' })}
-                  style={{ animationDelay: `${(index + 1) * 50}ms` }}
-                >
-                  {label}
-                </MenuItem>
-              )
-            )}
+            {items.length > 0 &&
+              items.map(
+                ({ label, target: { external, internal, blank } }, index) => (
+                  <MenuItem
+                    key={index}
+                    {...{ closeMenu, currentPath }}
+                    href={external || getEntityPath(internal)}
+                    {...(blank && { target: '_blank', rel: 'noreferrer' })}
+                    style={{ animationDelay: `${(index + 1) * 50}ms` }}
+                  >
+                    {label}
+                  </MenuItem>
+                )
+              )}
           </ul>
           <div className={styles.ticketButton}>
             <ButtonLink url={ticketsUrl} text="Tickets" openInNewTab={true} />


### PR DESCRIPTION
# Make `items` for `<Nav>` optional

## Intent

Get rid of TypeScript build error

## Description

`items` is required by the `Nav` component but wasn't passed the props. To me, it seems like it should be optional, so I updated the code accordingly. There's probably a better way to go about it, but it works
