### PR TITLE
Remove font-display:optional for Inter font

### DIFF
--- a/web/styles/globals.css
+++ b/web/styles/globals.css
@@ -2,7 +2,6 @@
   font-family: 'Inter';
   font-style: normal;
   font-weight: 100 900;
-  font-display: optional;
   src: url(/static/fonts/inter-var-latin.woff2) format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
     U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215,


### PR DESCRIPTION
# Remove font-display:optional for Inter font

## Intent

Multiple times we've seen the Inter font fail to load and thus the "arrows" showing up as "->" because the fallback font doesn't have that ligature. This PR aims to alleviate this issue.

## Description

Commit message has more details/thoughts on this.

## Testing this PR

It can be tricky to test this consistently because the issue is dependent on timing. Enabling network throttling in the browser's dev tools might be a good idea (e.g. set it to "Regular 3G" or lower speeds)

1. Open https://structured-content-2022-web-git-remove-optional-inter-fo-1e08c4.sanity.build/
2. Scroll down until an orange CTA button appears (e.g. "Tickets" in the header or "Get more info about the program" in the main page contents)
3. Verify that the button is showing an arrow at the end, not a hyphen and a greater-than sign separately with white space between (you can compare to structuredcontent.live if this PR has not yet been merged)