### PR TITLE
Sessions frontend, 1–2 speakers

### DIFF
--- a/web/components/SessionSpeakers/SessionSpeakers.module.css
+++ b/web/components/SessionSpeakers/SessionSpeakers.module.css
@@ -17,6 +17,14 @@
   display: none;
 }
 
+.speaker {
+  margin: 0;
+}
+
+.speaker.desktopOnly {
+  display: none;
+}
+
 .shape,
 .image {
   width: 148px;
@@ -25,19 +33,25 @@
 
 .image {
   border-radius: 16px;
+  vertical-align: top;
 }
 
-.image.desktopOnly {
-  display: none;
+.caption {
+  font: 400 12px/14px 'Inter', sans-serif;
+  letter-spacing: normal;
+  margin: 16px 8px 0;
+  text-align: center;
+  hyphens: auto;
+  overflow-wrap: break-word;
+}
+
+.speakerName {
+  font-weight: 600;
+  display: block;
+  margin-bottom: 2px;
 }
 
 @media (--medium-up) {
-  .shape,
-  .image {
-    width: 244px;
-    height: 372px;
-  }
-
   .column1 {
     grid-template-columns: repeat(3, 244px);
     gap: 16px;
@@ -45,6 +59,34 @@
 
   .container.hasTwoSpeakers .column1 {
     grid-template-columns: repeat(4, 244px);
+  }
+
+  .speaker {
+    position: relative;
+  }
+
+  .shape,
+  .image {
+    width: 244px;
+    height: 372px;
+  }
+
+  .caption {
+    margin: 0;
+    position: absolute;
+    left: 24px;
+    right: 24px;
+    bottom: 24px;
+    background: var(--color-brand-yellow);
+    padding: 12px 16px;
+    max-height: 25%;
+    overflow: auto;
+    border-radius: 8px;
+  }
+
+  .speakerName {
+    font: 600 16px/20px 'Inter', sans-serif;
+    letter-spacing: -0.011em;
   }
 }
 
@@ -72,6 +114,14 @@
     margin-top: -102px;
   }
 
+  .speaker.desktopOnly {
+    display: block;
+  }
+
+  .speaker.nonDesktop {
+    display: none;
+  }
+
   .shape {
     width: 256px;
     height: 256px;
@@ -80,13 +130,5 @@
   .image {
     width: 256px;
     height: 390px;
-  }
-
-  .image.desktopOnly {
-    display: block;
-  }
-
-  .image.nonDesktop {
-    display: none;
   }
 }

--- a/web/components/SessionSpeakers/SessionSpeakers.module.css
+++ b/web/components/SessionSpeakers/SessionSpeakers.module.css
@@ -1,0 +1,92 @@
+.container {
+  overflow: hidden;
+}
+
+.column1 {
+  display: grid;
+  grid-template-columns: repeat(3, 148px);
+  gap: 10px;
+  justify-content: center;
+}
+
+.container.hasTwoSpeakers .column1 {
+  grid-template-columns: repeat(4, 148px);
+}
+
+.column2 {
+  display: none;
+}
+
+.shape,
+.image {
+  width: 148px;
+  height: 226px;
+}
+
+.image {
+  border-radius: 16px;
+}
+
+.image.desktopOnly {
+  display: none;
+}
+
+@media (--medium-up) {
+  .shape,
+  .image {
+    width: 244px;
+    height: 372px;
+  }
+
+  .column1 {
+    grid-template-columns: repeat(3, 244px);
+    gap: 16px;
+  }
+
+  .container.hasTwoSpeakers .column1 {
+    grid-template-columns: repeat(4, 244px);
+  }
+}
+
+@media (--session-large-up) {
+  .container {
+    display: grid;
+    grid-template-columns: repeat(2, 256px);
+    gap: 21px;
+  }
+
+  .column1,
+  .column2 {
+    display: flex;
+    flex-direction: column;
+    width: 256px;
+    gap: 16px;
+    justify-content: flex-start;
+  }
+
+  .column1 {
+    margin-top: -198px;
+  }
+
+  .column2 {
+    margin-top: -102px;
+  }
+
+  .shape {
+    width: 256px;
+    height: 256px;
+  }
+
+  .image {
+    width: 256px;
+    height: 390px;
+  }
+
+  .image.desktopOnly {
+    display: block;
+  }
+
+  .image.nonDesktop {
+    display: none;
+  }
+}

--- a/web/components/SessionSpeakers/SessionSpeakers.tsx
+++ b/web/components/SessionSpeakers/SessionSpeakers.tsx
@@ -1,40 +1,59 @@
 import clsx from 'clsx';
-import type { Figure } from '../../types/Figure';
+import type { Person } from '../../types/Person';
 import { imageUrlFor } from '../../lib/sanity';
 import { useRandomShape } from '../../hooks/useRandomShape';
 import styles from './SessionSpeakers.module.css';
 
 interface SessionSpeakersProps {
-  photo?: Figure;
-  photo2?: Figure;
+  speaker1?: Person;
+  speaker2?: Person;
 }
 
 const Shape = () => (
   <div className={clsx(styles.shape, useRandomShape())} aria-hidden="true" />
 );
 
-const Speaker = ({ photo, variant }) => (
-  /* eslint-disable-next-line @next/next/no-img-element */
-  <img
-    src={imageUrlFor(photo).size(256, 390).saturation(-100).url()}
-    alt={photo.alt || ''}
-    className={clsx(styles.image, styles[variant])}
-    width={256}
-    height={390}
-  />
+const Speaker = ({
+  speaker,
+  variant,
+}: {
+  speaker: Person;
+  variant?: string;
+}) => (
+  <figure className={clsx(styles.speaker, variant && styles[variant])}>
+    {speaker.photo && (
+      /* eslint-disable-next-line @next/next/no-img-element */
+      <img
+        src={imageUrlFor(speaker.photo).size(256, 390).saturation(-100).url()}
+        alt={speaker.photo.alt || ''}
+        className={styles.image}
+        width={256}
+        height={390}
+      />
+    )}
+    <figcaption className={styles.caption}>
+      {speaker.name && (
+        <strong className={styles.speakerName}>{speaker.name}</strong>
+      )}
+      {[speaker.title, speaker.company].filter(Boolean).join(', ')}
+    </figcaption>
+  </figure>
 );
 
-export const SessionSpeakers = ({ photo, photo2 }: SessionSpeakersProps) => (
-  <div className={clsx(styles.container, photo2 && styles.hasTwoSpeakers)}>
+export const SessionSpeakers = ({
+  speaker1,
+  speaker2,
+}: SessionSpeakersProps) => (
+  <div className={clsx(styles.container, speaker2 && styles.hasTwoSpeakers)}>
     <div className={styles.column1}>
       <Shape />
-      {photo ? <Speaker photo={photo} /> : <Shape />}
-      {photo2 && <Speaker photo={photo2} variant="nonDesktop" />}
+      {speaker1 ? <Speaker speaker={speaker1} /> : <Shape />}
+      {speaker2 && <Speaker speaker={speaker2} variant="nonDesktop" />}
       <Shape />
     </div>
-    <div className={styles.column2} aria-hidden={photo2 ? null : 'true'}>
+    <div className={styles.column2} aria-hidden={speaker2 ? null : 'true'}>
       <Shape />
-      {photo2 && <Speaker photo={photo2} variant="desktopOnly" />}
+      {speaker2 && <Speaker speaker={speaker2} variant="desktopOnly" />}
       <Shape />
       <Shape />
     </div>

--- a/web/components/SessionSpeakers/SessionSpeakers.tsx
+++ b/web/components/SessionSpeakers/SessionSpeakers.tsx
@@ -1,0 +1,42 @@
+import clsx from 'clsx';
+import type { Figure } from '../../types/Figure';
+import { imageUrlFor } from '../../lib/sanity';
+import { useRandomShape } from '../../hooks/useRandomShape';
+import styles from './SessionSpeakers.module.css';
+
+interface SessionSpeakersProps {
+  photo?: Figure;
+  photo2?: Figure;
+}
+
+const Shape = () => (
+  <div className={clsx(styles.shape, useRandomShape())} aria-hidden="true" />
+);
+
+const Speaker = ({ photo, variant }) => (
+  /* eslint-disable-next-line @next/next/no-img-element */
+  <img
+    src={imageUrlFor(photo).size(256, 390).saturation(-100).url()}
+    alt={photo.alt || ''}
+    className={clsx(styles.image, styles[variant])}
+    width={256}
+    height={390}
+  />
+);
+
+export const SessionSpeakers = ({ photo, photo2 }: SessionSpeakersProps) => (
+  <div className={clsx(styles.container, photo2 && styles.hasTwoSpeakers)}>
+    <div className={styles.column1}>
+      <Shape />
+      {photo ? <Speaker photo={photo} /> : <Shape />}
+      {photo2 && <Speaker photo={photo2} variant="nonDesktop" />}
+      <Shape />
+    </div>
+    <div className={styles.column2} aria-hidden={photo2 ? null : 'true'}>
+      <Shape />
+      {photo2 && <Speaker photo={photo2} variant="desktopOnly" />}
+      <Shape />
+      <Shape />
+    </div>
+  </div>
+);

--- a/web/components/SessionSpeakers/index.ts
+++ b/web/components/SessionSpeakers/index.ts
@@ -1,0 +1,1 @@
+export { SessionSpeakers as default } from './SessionSpeakers';

--- a/web/pages/program/[slug].tsx
+++ b/web/pages/program/[slug].tsx
@@ -196,8 +196,8 @@ const SessionRoute = ({
                 (hasHighlightedSpeakers ? (
                   <div className={programStyles.highlightedSpeakers}>
                     <SessionSpeakers
-                      photo={speakers[0]?.person?.photo}
-                      photo2={speakers[1]?.person?.photo}
+                      speaker1={speakers[0]?.person}
+                      speaker2={speakers[1]?.person}
                     />
                   </div>
                 ) : (

--- a/web/pages/program/[slug].tsx
+++ b/web/pages/program/[slug].tsx
@@ -1,10 +1,12 @@
 import type { GetStaticPaths, GetStaticProps } from 'next';
 import { groq } from 'next-sanity';
+import clsx from 'clsx';
 import urlJoin from 'proper-url-join';
 import Footer from '../../components/Footer';
 import GridWrapper from '../../components/GridWrapper';
 import MetaTags from '../../components/MetaTags';
 import Nav from '../../components/Nav';
+import SessionSpeakers from '../../components/SessionSpeakers';
 import Tag from '../../components/Tag';
 import TextBlock from '../../components/TextBlock';
 import { imageUrlFor } from '../../lib/sanity';
@@ -144,6 +146,8 @@ const SessionRoute = ({
     currentSessionInProgram?._id,
     sessions
   );
+  const hasHighlightedSpeakers =
+    speakers?.length === 1 || speakers?.length === 2;
   return (
     <>
       <MetaTags title={title} description="" currentPath={`/session/${slug}`} />
@@ -155,7 +159,12 @@ const SessionRoute = ({
         />
       </header>
       <main>
-        <div className={programStyles.top}>
+        <div
+          className={clsx(
+            programStyles.top,
+            hasHighlightedSpeakers && programStyles.hasHighlightedSpeakers
+          )}
+        >
           <GridWrapper>
             <div className={programStyles.topContainer}>
               <div className={programStyles.sessionInfo}>
@@ -183,9 +192,17 @@ const SessionRoute = ({
                 )}
               </div>
 
-              {speakers && (
-                <SpeakerList speakers={speakers} />
-              )}
+              {speakers &&
+                (hasHighlightedSpeakers ? (
+                  <div className={programStyles.highlightedSpeakers}>
+                    <SessionSpeakers
+                      photo={speakers[0]?.person?.photo}
+                      photo2={speakers[1]?.person?.photo}
+                    />
+                  </div>
+                ) : (
+                  <SpeakerList speakers={speakers} />
+                ))}
             </div>
           </GridWrapper>
         </div>

--- a/web/pages/program/[slug].tsx
+++ b/web/pages/program/[slug].tsx
@@ -11,6 +11,7 @@ import { imageUrlFor } from '../../lib/sanity';
 import client from '../../lib/sanity.server';
 import { mainEventId } from '../../util/constants';
 import { PRIMARY_NAV } from '../../util/queries';
+import type { Person } from '../../types/Person';
 import type { Slug } from '../../types/Slug';
 import type { Session } from '../../types/Session';
 import {
@@ -89,6 +90,41 @@ interface SessionRouteProps {
   slug: string;
 }
 
+type SpeakerListInput = {
+  role: string;
+  person: Person;
+}[];
+
+const SpeakerList = ({ speakers }: { speakers: SpeakerListInput }) => (
+  <ul className={programStyles.speakers}>
+    {speakers.map(
+      ({ role, person: { _id, name, title, company, photo, slug } }) => (
+        <li key={_id} className={programStyles.speakerItem}>
+          <Link href={urlJoin('/speakers', slug.current)}>
+            <a className={programStyles.speakerLink}>
+              {photo && (
+                /* eslint-disable-next-line @next/next/no-img-element */
+                <img
+                  src={imageUrlFor(photo).size(64, 80).saturation(-100).url()}
+                  width={64}
+                  height={80}
+                  alt={name}
+                  className={programStyles.speakerImage}
+                />
+              )}
+              <div>
+                <div className={programStyles.role}>{role}</div>
+                <strong className={programStyles.speakerName}>{name}</strong>
+                <div>{[title, company].filter(Boolean).join(', ')}</div>
+              </div>
+            </a>
+          </Link>
+        </li>
+      )
+    )}
+  </ul>
+);
+
 const SessionRoute = ({
   data: {
     session: { title, longDescription, speakers, type },
@@ -148,43 +184,7 @@ const SessionRoute = ({
               </div>
 
               {speakers && (
-                <ul className={programStyles.speakers}>
-                  {speakers.map(
-                    ({
-                      role,
-                      person: { _id, name, title, company, photo, slug },
-                    }) => (
-                      <li key={_id} className={programStyles.speakerItem}>
-                        <Link href={urlJoin('/speakers', slug.current)}>
-                          <a className={programStyles.speakerLink}>
-                            {photo && (
-                              /* eslint-disable-next-line @next/next/no-img-element */
-                              <img
-                                src={imageUrlFor(photo)
-                                  .size(64, 80)
-                                  .saturation(-100)
-                                  .url()}
-                                width={64}
-                                height={80}
-                                alt={name}
-                                className={programStyles.speakerImage}
-                              />
-                            )}
-                            <div>
-                              <div className={programStyles.role}>{role}</div>
-                              <strong className={programStyles.speakerName}>
-                                {name}
-                              </strong>
-                              <div>
-                                {[title, company].filter(Boolean).join(', ')}
-                              </div>
-                            </div>
-                          </a>
-                        </Link>
-                      </li>
-                    )
-                  )}
-                </ul>
+                <SpeakerList speakers={speakers} />
               )}
             </div>
           </GridWrapper>

--- a/web/pages/program/program.module.css
+++ b/web/pages/program/program.module.css
@@ -18,6 +18,10 @@
   max-width: var(--max-body-text-width);
 }
 
+.highlightedSpeakers {
+  margin: 80px calc(-1 * var(--grid-half-gutter)) 0;
+}
+
 .speakers {
   margin: 80px auto 0;
   max-width: var(--max-body-text-width);
@@ -94,6 +98,14 @@
     margin-bottom: 32px;
   }
 
+  .sessionTitle {
+    font: var(--font-display-xl);
+  }
+
+  .highlightedSpeakers {
+    margin: 96px calc(-1 * var(--grid-medium-gutter)) 0;
+  }
+
   .speakers {
     margin-top: 96px;
   }
@@ -106,9 +118,14 @@
   }
 }
 
-@media (--large-up) {
+@media (--session-large-up) {
   .top {
     padding: 88px 0 80px;
+  }
+
+  .top.hasHighlightedSpeakers {
+    position: relative;
+    min-height: 630px;
   }
 
   .topContainer {
@@ -118,14 +135,26 @@
     align-items: center;
   }
 
+  .top.hasHighlightedSpeakers .topContainer {
+    margin-top: 40px;
+  }
+
   .sessionInfo {
     text-align: left;
     grid-column: 2 / span 6;
   }
 
   .sessionTitle {
-    font: var(--font-display-xl);
     margin: 0 0 32px;
+  }
+
+  .highlightedSpeakers {
+    margin: 0;
+    position: absolute;
+    top: 0;
+    right: 16px;
+    height: 630px;
+    overflow: hidden;
   }
 
   .speakers {

--- a/web/styles/media.css
+++ b/web/styles/media.css
@@ -1,3 +1,4 @@
 @custom-media --small-up (min-width: 390px);
 @custom-media --medium-up (min-width: 768px);
 @custom-media --large-up (min-width: 1025px);
+@custom-media --session-large-up (min-width: 1310px);


### PR DESCRIPTION
# Sessions frontend, 1–2 speakers

## Intent

Implement the custom layout of speakers on the session details page in the case when there are only 1 or 2 speakers. Shortcut story [Session details page: front-end 1+2 speakers](https://app.shortcut.com/sanity-io/story/17072/sessions-details-page-front-end-1-2-speakers)

## Description

I had originally planned to adapt the `HighlightedSpeakerBlock` component for this use, but unfortunately there seems to be so many small differences in the Figma sketches that I ended up implementing a separate component instead (based on a copy/paste of the former).

As discussed in [Slack](https://wja.slack.com/archives/C02E2ERKR7E/p1649323933187139) the Figma sketches for desktop are significantly wider than the narrowest viewport that qualifies, so this page uses a custom breakpoint to try to ensure that there's actually enough room for two images side by side (without having to severely shrink them, which also affects the text blocks within that show the speakers' name/title/company). (This also contributes to the divergence of HighlightedSpeakerBlock and SessionSpeakers.)

## Testing this PR

1. Open https://structured-content-2022-web-git-sessions-frontend-1-2-speakers.sanity.build/program/cross-functional-collaboration-for-structured-content  (2 speakers), verify that the speaker presentation looks OK and in accordance with the Figma sketch (linked in Shortcut) 
2. Open https://structured-content-2022-web-git-sessions-frontend-1-2-speakers.sanity.build/program/workshop-lunch (1 speaker), verify that the speaker presentation looks OK