### PR TITLE
feat: fix queries for sponsors section

### DIFF
--- a/studio/prettier.config.js
+++ b/studio/prettier.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  semi: true,
+  singleQuote: false,
+  trailingComma: 'es5',
+  bracketSpacing: true,
+};

--- a/studio/schemas/sections/sponsorsSection.ts
+++ b/studio/schemas/sections/sponsorsSection.ts
@@ -48,4 +48,9 @@ export default {
       ],
     },
   ],
+  preview: {
+    select: {
+      title: "type",
+    },
+  },
 };

--- a/web/components/TextBlock/SponsorsSection/SponsorsSection.module.css
+++ b/web/components/TextBlock/SponsorsSection/SponsorsSection.module.css
@@ -1,3 +1,7 @@
+.root {
+  margin-bottom: 128px;
+}
+
 .sponsorLevel {
   text-align: center;
   background: var(--color-ui-gray-100);

--- a/web/components/TextBlock/SponsorsSection/SponsorsSection.tsx
+++ b/web/components/TextBlock/SponsorsSection/SponsorsSection.tsx
@@ -53,7 +53,6 @@ export const SponsorsSection = ({
   }
 
   if (type === 'all') {
-    console.log(allSponsorships);
     return (
       <GridWrapper>
         <div className={styles.root}>

--- a/web/components/TextBlock/SponsorsSection/SponsorsSection.tsx
+++ b/web/components/TextBlock/SponsorsSection/SponsorsSection.tsx
@@ -37,36 +37,41 @@ export const SponsorsSection = ({
 
     return (
       <GridWrapper>
-        <section className={styles.sponsorLevel}>
-          <ul className={styles.sponsors}>
-            {sponsors.map((sponsor) => (
-              <li key={sponsor._id} className={styles.sponsor}>
-                <Sponsor sponsor={sponsor} />
-              </li>
-            ))}
-          </ul>
-        </section>
+        <div className={styles.root}>
+          <section className={styles.sponsorLevel}>
+            <ul className={styles.sponsors}>
+              {sponsors.map((sponsor) => (
+                <li key={sponsor._id} className={styles.sponsor}>
+                  <Sponsor sponsor={sponsor} />
+                </li>
+              ))}
+            </ul>
+          </section>
+        </div>
       </GridWrapper>
     );
   }
 
   if (type === 'all') {
+    console.log(allSponsorships);
     return (
       <GridWrapper>
-        {allSponsorships
-          .filter((sponsorship) => sponsorship.sponsors?.length > 0)
-          .map(({ _id, type, sponsors }) => (
-            <section key={_id} className={styles.sponsorLevel}>
-              <Heading type="h3">{type}</Heading>
-              <ul className={styles.sponsors}>
-                {sponsors.map((sponsor) => (
-                  <li key={sponsor._key} className={styles.sponsor}>
-                    <Sponsor sponsor={sponsor as TSponsor} type={type} />
-                  </li>
-                ))}
-              </ul>
-            </section>
-          ))}
+        <div className={styles.root}>
+          {allSponsorships
+            .filter((sponsorship) => sponsorship.sponsors?.length > 0)
+            .map(({ _id, type, sponsors }) => (
+              <section key={_id} className={styles.sponsorLevel}>
+                <Heading type="h3">{type}</Heading>
+                <ul className={styles.sponsors}>
+                  {sponsors.map((sponsor) => (
+                    <li key={sponsor._key} className={styles.sponsor}>
+                      <Sponsor sponsor={sponsor as TSponsor} type={type} />
+                    </li>
+                  ))}
+                </ul>
+              </section>
+            ))}
+        </div>
       </GridWrapper>
     );
   }

--- a/web/pages/[[...slug]].tsx
+++ b/web/pages/[[...slug]].tsx
@@ -28,6 +28,7 @@ import {
   QUESTION_AND_ANSWER_COLLECTION_SECTION,
   SIMPLE_CALL_TO_ACTION,
   SPEAKER_FRONTPAGE,
+  SPONSOR,
   SPONSORSHIP,
   TEXT_AND_IMAGE_SECTION,
   TICKET,
@@ -64,8 +65,8 @@ const SHARED_SECTIONS = `
   },
   _type == "sponsorsSection" => {
     ...,
-    sponsors[]->,
-    "allSponsorships": *[_id == "${mainEventId}"][0].sponsorships[]->,
+    sponsors[]->{ ${SPONSOR} },
+    "allSponsorships": *[_id == "${mainEventId}"][0].sponsorships[]-> { ${SPONSORSHIP} },
   },
   _type == "sponsorshipsSection" => {
     ...,

--- a/web/util/queries.ts
+++ b/web/util/queries.ts
@@ -89,6 +89,16 @@ const SPEAKER_FRONTPAGE = `
   company,
 `;
 
+const SPONSOR = `
+  _id,
+  _type,
+  _key,
+  callToActionURL,
+  image,
+  title,
+  url,
+`;
+
 const SPONSORSHIP = `
   _createdAt,
   _id,
@@ -111,6 +121,7 @@ const SPONSORSHIP = `
   },
   price,
   type,
+  sponsors[]->{ ${SPONSOR} },
 `;
 
 const PRIMARY_NAV = `
@@ -131,6 +142,7 @@ export {
   TEXT_AND_IMAGE_SECTION,
   TICKET,
   SPONSORSHIP,
+  SPONSOR,
   SPEAKER,
   SPEAKER_FRONTPAGE,
   PRIMARY_NAV,


### PR DESCRIPTION
# feat: fix queries for sponsors section

## Intent

Make sponsors show up on the front-page.

## Description

Studio:
- Added prettier config to match current formatting style.
- Updated the preview title of the sponsors section in the Studio to avoid "No name" as the title.

Web:
- Added a `SPONSOR` query to fetch data for each sponsor in the sponsors section.
- Added bottom margin to sponsorship section component to match Figma sketches.

## Testing this PR

1. Open the preview build
2. Verify that two sponsors show up on the root page (`/`)
