### PR TITLE
fix: remove minimum # sponsors validation

### DIFF
--- a/studio/schemas/documents/sponsorship.ts
+++ b/studio/schemas/documents/sponsorship.ts
@@ -58,7 +58,6 @@ export default {
       of: [{ type: "reference", to: [{ type: "sponsor" }] }],
       validation: (Rule) => [
         Rule.unique(),
-        Rule.min(1),
         Rule.max(Rule.valueOfField("available")),
       ],
     },


### PR DESCRIPTION
# fix: remove minimum # sponsors validation

## Intent

Make it possible to have zero sponsors in a sponsorship type

## Description

Removed `Rule.min(1)` validation from `sponsors` field in the `sponsorship` document.
