### PR TITLE
Additional metadata for Speakers, Sessions pages

### DIFF
--- a/web/components/MetaTags/MetaTags.tsx
+++ b/web/components/MetaTags/MetaTags.tsx
@@ -40,10 +40,7 @@ export const MetaTags = ({
         images: [
           image
             ? {
-                url: imageUrlFor(image)
-                  .ignoreImageParams()
-                  .size(1260, 630)
-                  .url(),
+                url: imageUrlFor(image).size(1260, 630).url(),
                 alt: image.alt,
               }
             : {

--- a/web/pages/program/[slug].tsx
+++ b/web/pages/program/[slug].tsx
@@ -159,11 +159,7 @@ const SessionRoute = ({
   );
   const formattedDuration =
     hasAssociatedProgram &&
-    formatTimeRange(
-      start,
-      currentSessionInProgram?.duration,
-      mainVenueTimezone
-    );
+    formatTimeRange(start, currentSessionInProgram.duration, mainVenueTimezone);
   const description = hasAssociatedProgram
     ? `${formattedStartDate} ${formattedDuration} ${formattedTimezone}`
     : '';

--- a/web/pages/program/[slug].tsx
+++ b/web/pages/program/[slug].tsx
@@ -148,11 +148,32 @@ const SessionRoute = ({
     currentSessionInProgram?._id,
     sessions
   );
+  const hasAssociatedProgram = startDateTime && currentSessionInProgram;
   const hasHighlightedSpeakers =
     speakers?.length === 1 || speakers?.length === 2;
+  const formattedStartDate = formatDateWithDay(start, mainVenueTimezone, ', ');
+  const formattedTimezone = getNonLocationTimezone(
+    start,
+    mainVenueTimezone,
+    true
+  );
+  const formattedDuration =
+    hasAssociatedProgram &&
+    formatTimeRange(
+      start,
+      currentSessionInProgram?.duration,
+      mainVenueTimezone
+    );
+  const description = hasAssociatedProgram
+    ? `${formattedStartDate} ${formattedDuration} ${formattedTimezone}`
+    : '';
   return (
     <>
-      <MetaTags title={title} description="" currentPath={`/session/${slug}`} />
+      <MetaTags
+        title={title}
+        description={description}
+        currentPath={`/session/${slug}`}
+      />
       <header className={styles.header}>
         <Nav
           currentPath={`/session/${slug}`}
@@ -177,18 +198,11 @@ const SessionRoute = ({
                 )}
                 <h1 className={programStyles.sessionTitle}>{title}</h1>
 
-                {startDateTime && currentSessionInProgram && (
+                {hasAssociatedProgram && (
                   <>
+                    <div>{formattedStartDate}</div>
                     <div>
-                      {formatDateWithDay(start, mainVenueTimezone, ', ')}
-                    </div>
-                    <div>
-                      {formatTimeRange(
-                        start,
-                        currentSessionInProgram.duration,
-                        mainVenueTimezone
-                      )}{' '}
-                      {getNonLocationTimezone(start, mainVenueTimezone, true)}
+                      {formattedDuration} {formattedTimezone}
                     </div>
                   </>
                 )}

--- a/web/pages/program/[slug].tsx
+++ b/web/pages/program/[slug].tsx
@@ -2,6 +2,7 @@ import type { GetStaticPaths, GetStaticProps } from 'next';
 import { groq } from 'next-sanity';
 import clsx from 'clsx';
 import urlJoin from 'proper-url-join';
+import { toPlainText } from '@portabletext/react';
 import Footer from '../../components/Footer';
 import GridWrapper from '../../components/GridWrapper';
 import MetaTags from '../../components/MetaTags';
@@ -33,6 +34,7 @@ const QUERY = groq`
       _id,
       title,
       duration,
+      shortDescription,
       longDescription,
       speakers[] {
         role,
@@ -131,7 +133,7 @@ const SpeakerList = ({ speakers }: SpeakerListProps) => (
 
 const SessionRoute = ({
   data: {
-    session: { title, longDescription, speakers, type },
+    session: { title, shortDescription, longDescription, speakers, type },
     home: { ticketsUrl },
     navItems,
     footer,
@@ -145,19 +147,11 @@ const SessionRoute = ({
 }: SessionRouteProps) => {
   const hasHighlightedSpeakers = [1, 2].includes(speakers?.length);
   const start = sessionStart(startDateTime, session?._id, sessions);
-  const formattedStartDate = start && formatDateWithDay(start, timezone, ', ');
-  const formattedDuration =
-    start && formatTimeRange(start, session?.duration, timezone);
-  const formattedTimezone =
-    start && getNonLocationTimezone(start, timezone, true);
-  const description = start
-    ? `${formattedStartDate} ${formattedDuration} ${formattedTimezone}`
-    : '';
   return (
     <>
       <MetaTags
         title={title}
-        description={description}
+        description={shortDescription ? toPlainText(shortDescription) : ''}
         currentPath={`/session/${slug}`}
       />
       <header className={styles.header}>
@@ -186,9 +180,10 @@ const SessionRoute = ({
 
                 {start && (
                   <>
-                    <div>{formattedStartDate}</div>
+                    <div>{formatDateWithDay(start, timezone, ', ')}</div>
                     <div>
-                      {formattedDuration} {formattedTimezone}
+                      {formatTimeRange(start, session?.duration, timezone)}{' '}
+                      {getNonLocationTimezone(start, timezone, true)}
                     </div>
                   </>
                 )}

--- a/web/pages/speakers/[slug].tsx
+++ b/web/pages/speakers/[slug].tsx
@@ -114,7 +114,8 @@ const SpeakersRoute = ({
     <MetaTags
       title={`${name} – Structured Content 2022`}
       description={`Speaker page for ${name}`}
-      currentPath={`speakers/${slug}`}
+      currentPath={`/speakers/${slug}`}
+      image={photo}
     />
     <header className={styles.header}>
       <Nav

--- a/web/util/session.ts
+++ b/web/util/session.ts
@@ -15,7 +15,7 @@ export const sessionStart = (
   sessionId: string,
   sessions: Pick<Session, '_id' | 'duration'>[]
 ) => {
-  if (!programStart) {
+  if (!programStart || !sessionId) {
     return null;
   }
 


### PR DESCRIPTION
# Additional metadata for Speakers, Sessions pages

## Intent

Solves [this](https://app.shortcut.com/sanity-io/story/17753/generate-og-images-for-speaker-pages-based-on-speaker-photo-where-available-for-previews-on-facebook-twitter-etc) Shortcut Story.

## Description

- Pass Speaker's `photo` to `<MetaTags />` in _/speakers/[slug].tsx_
- If associated with a Program, also pass Session's start date, time, duration for SF timezone in _/program/[slug].tsx_

## Testing this PR


1. Go to https://metatags.io/ and enter https://structured-content-2022-web-git-metadata-for-speakers-sessions.sanity.build/speakers/simen-svale-skogsrud in the input field at the top of the page. (The page is loaded on the field's `onblur` event, it seems; click somewhere else after inputting the field to load the contents.) Verify that the photo of Simen is the one that's loaded, as opposed to the default image that's currently shown for https://structuredcontent.live/speakers/simen-svale-skogsrud.
2. Still at metatags.io, enter a Session that's associated with the main San Francisco venue, e.g. https://structured-content-2022-web-git-metadata-for-speakers-sessions.sanity.build/program/workshop-2022. Verify that _Tuesday, May 24 9:00 AM – 12:30 PM PDT_ is displayed in the meta description field.
3. Enter a Session that's not associated with the SF program, e.g. https://structured-content-2022-web-git-metadata-for-speakers-sessions.sanity.build/program/sessions-2. Verify that you can still access the page for the session without encountering any errors or warnings, and that metatags.io render's the respective page's description field as empty.
