### PR TITLE
Session details: show dates & times for all Venues referencing Session

### DIFF
--- a/web/components/Footer/Footer.module.css
+++ b/web/components/Footer/Footer.module.css
@@ -45,7 +45,9 @@
 
 .separator {
   border-top: 1px solid;
-  border-color: var(--color-ui-gray-900); /* Chrome doesn't set border color here if using shorthand property */
+  border-color: var(
+    --color-ui-gray-900
+  ); /* Chrome doesn't set border color here if using shorthand property */
   width: 100%;
   margin: 0;
   padding: 0;

--- a/web/components/Footer/Footer.tsx
+++ b/web/components/Footer/Footer.tsx
@@ -7,7 +7,7 @@ import linkedinLogo from '../../images/linkedin_logo_black.svg';
 import GridWrapper from '../GridWrapper';
 import styles from './Footer.module.css';
 import { Slug } from '../../types/Slug';
-import urlJoin from "proper-url-join";
+import urlJoin from 'proper-url-join';
 
 interface FooterProps {
   links: {
@@ -30,16 +30,13 @@ export const Footer = ({ links }: FooterProps) => (
           <Image src={sanityLogo} alt="Sanity" width={162} height={46} />
         </a>
       </div>
-
       <p>Structured Content 2022 is a conference by Sanity</p>
-
       Inquiries:
       <address>
         <a className={styles.mailLink} href="mailto:confinfo@sanity.io">
           confinfo@sanity.io
         </a>
       </address>
-
       <ul className={styles.social}>
         <li className={styles.socialItem}>
           <a

--- a/web/components/TextBlock/Programs/Programs.tsx
+++ b/web/components/TextBlock/Programs/Programs.tsx
@@ -8,6 +8,7 @@ import { getCollectionForSelectionType } from '../../../util/entity';
 import {
   formatDateWithDay,
   formatTime,
+  formatTimeRange,
   getNonLocationTimezone,
 } from '../../../util/date';
 import Accordion from '../../Accordion';
@@ -73,12 +74,9 @@ export const Programs = ({
                             <>
                               <div className={styles.sessionItem}>
                                 <h4 className={styles.sessionDuration}>
-                                  {formatTime(currentTime, timezone)} -{' '}
-                                  {formatTime(
-                                    addMinutes(
-                                      currentTime,
-                                      session.session.duration
-                                    ),
+                                  {formatTimeRange(
+                                    currentTime,
+                                    session.session.duration,
                                     timezone
                                   )}
                                 </h4>

--- a/web/pages/program/[slug].tsx
+++ b/web/pages/program/[slug].tsx
@@ -23,8 +23,6 @@ import type { Session } from '../../types/Session';
 import { sessionTimingDetailsForMatchingPrograms } from '../../util/session';
 import styles from '../app.module.css';
 import programStyles from './program.module.css';
-import { formatTimeDuration } from '../../util/date';
-import { parseISO } from 'date-fns';
 
 const QUERY = groq`
   {

--- a/web/pages/program/[slug].tsx
+++ b/web/pages/program/[slug].tsx
@@ -173,9 +173,10 @@ const SessionRoute = ({
                   ({ time, label, timezone, date }) => (
                     <p key={time}>
                       <strong>{label}</strong>
-                      {/* should these be <time> tags? */}
-                      <span style={{ display: 'block' }}>{date}</span>
-                      <span style={{ display: 'block' }}>
+                      <span className={programStyles.sessionVenueDateTime}>
+                        {date}
+                      </span>
+                      <span className={programStyles.sessionVenueDateTime}>
                         {time} {timezone}
                       </span>
                     </p>

--- a/web/pages/program/[slug].tsx
+++ b/web/pages/program/[slug].tsx
@@ -23,6 +23,8 @@ import type { Session } from '../../types/Session';
 import { sessionTimingDetailsForMatchingPrograms } from '../../util/session';
 import styles from '../app.module.css';
 import programStyles from './program.module.css';
+import { formatTimeDuration } from '../../util/date';
+import { parseISO } from 'date-fns';
 
 const QUERY = groq`
   {
@@ -170,15 +172,21 @@ const SessionRoute = ({
                 <h1 className={programStyles.sessionTitle}>{title}</h1>
 
                 {matchingSessionsInPrograms.map(
-                  ({ time, label, timezone, date }) => (
-                    <p key={time}>
+                  ({ label, time, timezone, rawDate, date, duration }) => (
+                    <p key={label}>
                       <strong>{label}</strong>
-                      <span className={programStyles.sessionVenueDateTime}>
+                      <time
+                        dateTime={rawDate}
+                        className={programStyles.sessionVenueDateTime}
+                      >
                         {date}
-                      </span>
-                      <span className={programStyles.sessionVenueDateTime}>
+                      </time>
+                      <time
+                        dateTime={duration}
+                        className={programStyles.sessionVenueDateTime}
+                      >
                         {time} {timezone}
-                      </span>
+                      </time>
                     </p>
                   )
                 )}

--- a/web/pages/program/[slug].tsx
+++ b/web/pages/program/[slug].tsx
@@ -51,6 +51,7 @@ const QUERY = groq`
     "programs": *[_id == "${mainEventId}"].venues[]-> {
       "program": *[_type == "program" && references(^._id)] { ${PROGRAM} }
     }["program"][],
+    "mainVenueName": (*[_id == "${mainEventId}"].venues[0]->.name)[0],
   }`;
 
 interface SessionRouteProps {
@@ -76,6 +77,7 @@ interface SessionRouteProps {
       };
     };
     programs: Program[];
+    mainVenueName: string;
   };
   slug: string;
 }
@@ -128,6 +130,7 @@ const SessionRoute = ({
     navItems,
     footer,
     programs,
+    mainVenueName,
   },
   slug,
 }: SessionRouteProps) => {
@@ -139,7 +142,7 @@ const SessionRoute = ({
     _id
   ).map(({ label, ...rest }) => ({
     // Ad-hoc override for the SF venue, for this specific view only
-    label: label === 'San Francisco' ? 'San Francisco & Virtual' : label,
+    label: label === mainVenueName ? 'San Francisco & Virtual' : label,
     ...rest,
   }));
   return (

--- a/web/pages/program/[slug].tsx
+++ b/web/pages/program/[slug].tsx
@@ -164,29 +164,21 @@ const SessionRoute = ({
         >
           <GridWrapper>
             <div className={programStyles.topContainer}>
-              <div className={programStyles.sessionInfo}>
+              <div className={programStyles.info}>
                 {type === 'workshop' && (
                   <div className={programStyles.tag}>
                     <Tag>Workshop</Tag>
                   </div>
                 )}
-                <h1 className={programStyles.sessionTitle}>{title}</h1>
+                <h1 className={programStyles.title}>{title}</h1>
 
                 <ul className={programStyles.venueTimes}>
                   {matchingSessionsInPrograms.map(
                     ({ label, time, timezone, rawDate, date, duration }) => (
                       <li className={programStyles.venueTime} key={label}>
                         <strong>{label}</strong>
-                        <time
-                          dateTime={rawDate}
-                          className={programStyles.sessionVenueDateTime}
-                        >
-                          {date}
-                        </time>
-                        <time
-                          dateTime={duration}
-                          className={programStyles.sessionVenueDateTime}
-                        >
+                        <time dateTime={rawDate}>{date}</time>
+                        <time dateTime={duration}>
                           {time} {timezone}
                         </time>
                       </li>

--- a/web/pages/program/[slug].tsx
+++ b/web/pages/program/[slug].tsx
@@ -135,7 +135,11 @@ const SessionRoute = ({
   const matchingSessionsInPrograms = sessionTimingDetailsForMatchingPrograms(
     programs,
     _id
-  );
+  ).map(({ label, ...rest }) => ({
+    // Ad-hoc override for the SF venue, for this specific view only
+    label: label === 'San Francisco' ? 'San Francisco & Virtual' : label,
+    ...rest,
+  }));
   return (
     <>
       <MetaTags title={title} description="" currentPath={`/session/${slug}`} />

--- a/web/pages/program/[slug].tsx
+++ b/web/pages/program/[slug].tsx
@@ -48,7 +48,9 @@ const QUERY = groq`
         _id,
       }
     },
-    "programs": *[_type == "program"] { ${PROGRAM} },
+    "programs": *[_id == "${mainEventId}"].venues[]-> {
+      "program": *[_type == "program" && references(^._id)] { ${PROGRAM} }
+    }["program"][],
   }`;
 
 interface SessionRouteProps {

--- a/web/pages/program/[slug].tsx
+++ b/web/pages/program/[slug].tsx
@@ -142,7 +142,7 @@ const SessionRoute = ({
     _id
   ).map(({ label, ...rest }) => ({
     // Ad-hoc override for the SF venue, for this specific view only
-    label: label === mainVenueName ? 'San Francisco & Virtual' : label,
+    label: label === mainVenueName ? `${label} & Virtual` : label,
     ...rest,
   }));
   return (

--- a/web/pages/program/[slug].tsx
+++ b/web/pages/program/[slug].tsx
@@ -172,25 +172,27 @@ const SessionRoute = ({
                 )}
                 <h1 className={programStyles.sessionTitle}>{title}</h1>
 
-                {matchingSessionsInPrograms.map(
-                  ({ label, time, timezone, rawDate, date, duration }) => (
-                    <p key={label}>
-                      <strong>{label}</strong>
-                      <time
-                        dateTime={rawDate}
-                        className={programStyles.sessionVenueDateTime}
-                      >
-                        {date}
-                      </time>
-                      <time
-                        dateTime={duration}
-                        className={programStyles.sessionVenueDateTime}
-                      >
-                        {time} {timezone}
-                      </time>
-                    </p>
-                  )
-                )}
+                <ul className={programStyles.venueTimes}>
+                  {matchingSessionsInPrograms.map(
+                    ({ label, time, timezone, rawDate, date, duration }) => (
+                      <li className={programStyles.venueTime} key={label}>
+                        <strong>{label}</strong>
+                        <time
+                          dateTime={rawDate}
+                          className={programStyles.sessionVenueDateTime}
+                        >
+                          {date}
+                        </time>
+                        <time
+                          dateTime={duration}
+                          className={programStyles.sessionVenueDateTime}
+                        >
+                          {time} {timezone}
+                        </time>
+                      </li>
+                    )
+                  )}
+                </ul>
               </div>
 
               {speakers &&

--- a/web/pages/program/program.module.css
+++ b/web/pages/program/program.module.css
@@ -18,6 +18,10 @@
   max-width: var(--max-body-text-width);
 }
 
+.sessionVenueDateTime {
+  display: block;
+}
+
 .highlightedSpeakers {
   margin: 80px calc(-1 * var(--grid-half-gutter)) 0;
 }

--- a/web/pages/program/program.module.css
+++ b/web/pages/program/program.module.css
@@ -3,7 +3,7 @@
   background-color: var(--color-brand-yellow-light);
 }
 
-.sessionInfo {
+.info {
   text-align: center;
   font: var(--font-body-small-medium);
   letter-spacing: var(--letter-spacing-body-small);
@@ -13,7 +13,7 @@
   margin-bottom: 24px;
 }
 
-.sessionTitle {
+.title {
   margin: 0 auto 24px;
   max-width: var(--max-body-text-width);
 }
@@ -23,12 +23,13 @@
   list-style: none;
 }
 
-.venueTime:not(:last-of-type) {
-  margin-bottom: 16px;
+.venueTime {
+  display: flex;
+  flex-direction: column;
 }
 
-.sessionVenueDateTime {
-  display: block;
+.venueTime:not(:last-of-type) {
+  margin-bottom: 16px;
 }
 
 .highlightedSpeakers {
@@ -101,17 +102,17 @@
     padding: 108px 0 64px;
   }
 
-  .sessionInfo {
+  .info {
     font: var(--font-body-base-medium);
     letter-spacing: var(--letter-spacing-body-base);
   }
 
   .tag,
-  .sessionTitle {
+  .title {
     margin-bottom: 32px;
   }
 
-  .sessionTitle {
+  .title {
     font: var(--font-display-xl);
   }
 
@@ -152,12 +153,12 @@
     margin-top: 40px;
   }
 
-  .sessionInfo {
+  .info {
     text-align: left;
     grid-column: 2 / span 6;
   }
 
-  .sessionTitle {
+  .title {
     margin: 0 0 32px;
   }
 

--- a/web/pages/program/program.module.css
+++ b/web/pages/program/program.module.css
@@ -20,16 +20,14 @@
 
 .venueTimes {
   padding: 0;
+  margin: 0;
   list-style: none;
 }
 
 .venueTime {
   display: flex;
   flex-direction: column;
-}
-
-.venueTime:not(:last-of-type) {
-  margin-bottom: 16px;
+  margin-top: 16px;
 }
 
 .highlightedSpeakers {

--- a/web/pages/program/program.module.css
+++ b/web/pages/program/program.module.css
@@ -18,6 +18,15 @@
   max-width: var(--max-body-text-width);
 }
 
+.venueTimes {
+  padding: 0;
+  list-style: none;
+}
+
+.venueTime:not(:last-of-type) {
+  margin-bottom: 16px;
+}
+
 .sessionVenueDateTime {
   display: block;
 }

--- a/web/types/Program.ts
+++ b/web/types/Program.ts
@@ -1,16 +1,18 @@
 import { Session } from './Session';
 import { Venue } from './Venue';
 
+export type ProgramSession = {
+  duration?: number;
+  durationOverride?: number;
+  _key: string;
+  _type: 'padding' | 'slot';
+  session?: Session;
+};
+
 export type Program = {
   _id: string;
   internalName: string;
-  sessions: {
-    duration?: number;
-    durationOverride?: number;
-    _key: string;
-    _type: 'padding' | 'slot';
-    session?: Session;
-  }[];
+  sessions: ProgramSession[];
   startDateTime: string;
   venues: Venue[];
 };

--- a/web/types/Program.ts
+++ b/web/types/Program.ts
@@ -6,6 +6,7 @@ export type Program = {
   internalName: string;
   sessions: {
     duration?: number;
+    durationOverride?: number;
     _key: string;
     _type: 'padding' | 'slot';
     session?: Session;

--- a/web/util/date.ts
+++ b/web/util/date.ts
@@ -3,7 +3,7 @@ import { addMinutes, intervalToDuration } from 'date-fns';
 import enUS from 'date-fns/locale/en-US';
 
 export const formatTime = (date: Date, timezone: string, meridiem?: boolean) =>
-  formatInTimeZone(date, timezone, meridiem ? 'h:mm aa' : 'HH:mm', {
+  formatInTimeZone(date, timezone, `h:mm${meridiem ? ' aa' : ''}`, {
     locale: enUS,
   });
 

--- a/web/util/date.ts
+++ b/web/util/date.ts
@@ -2,10 +2,19 @@ import { formatInTimeZone } from 'date-fns-tz';
 import { addMinutes, intervalToDuration } from 'date-fns';
 import enUS from 'date-fns/locale/en-US';
 
-export const formatTime = (date: Date, timezone: string, meridiem?: boolean) =>
-  formatInTimeZone(date, timezone, `h:mm${meridiem ? ' aa' : ''}`, {
-    locale: enUS,
-  });
+export const formatTime = (
+  date: Date,
+  timezone: string,
+  hideMeridiemIndicator?: boolean
+) =>
+  formatInTimeZone(
+    date,
+    timezone,
+    `h:mm${hideMeridiemIndicator ? '' : ' aa'}`,
+    {
+      locale: enUS,
+    }
+  );
 
 export const formatDate = (date: Date, timezone: string) =>
   formatInTimeZone(date, timezone, 'MMMM d, yyyy', { locale: enUS });
@@ -39,9 +48,9 @@ export const formatTimeRange = (
   const end = addMinutes(start, duration);
   const isDifferingMeridiem = differingMeridiem(start, end, timezone);
   return [
-    formatTime(start, timezone, isDifferingMeridiem),
+    formatTime(start, timezone, !isDifferingMeridiem),
     isDifferingMeridiem ? ' – ' : '–',
-    formatTime(end, timezone, true),
+    formatTime(end, timezone),
   ].join('');
 };
 

--- a/web/util/queries.ts
+++ b/web/util/queries.ts
@@ -25,7 +25,7 @@ const PROGRAM = `
   startDateTime,
   sessions[] {
     ...,
-    session->{ duration, title },
+    session->{ _id, duration, title },
   },
   venues[]->{ name, timezone },
 `;

--- a/web/util/session.ts
+++ b/web/util/session.ts
@@ -7,6 +7,7 @@ import {
   formatTimeRange,
   getNonLocationTimezone,
 } from './date';
+import { format, formatInTimeZone } from 'date-fns-tz';
 
 const minutesFromProgramStart = (
   sessions: Pick<Session, 'duration'>[],
@@ -39,11 +40,11 @@ const getDuration = ({ session, duration, durationOverride }: ProgramSession) =>
 /* Given all Programs, finds the Programs that contain the Session (matching on sessionId === _id).
  * For each match, returns:
  * - label: Program's associated Venue name (using the first entry in the Program's Venues array)
- * - rawDate: the Session's date (based on the Session's start time)
- * - date: rawDate, but formatted
- * - time: the Session's time range, formatted (accounting for any duration overrides)
- * - duration: the Session's duration, formatted
- * - timezone: the Session's timezone, formatted
+ * - rawDate: the Session's start date and time, global date and time string
+ * - date: the Session's date, human-readable string
+ * - time: the Session's time range accounting for any duration overrides, human-readable string
+ * - duration: the Session's duration, human-readable string
+ * - timezone: the Session's timezone, human-readable string
  */
 export const sessionTimingDetailsForMatchingPrograms = (
   programs: Program[],
@@ -66,14 +67,13 @@ export const sessionTimingDetailsForMatchingPrograms = (
       );
 
       const [{ name, timezone }] = venues;
-      const startDate = parseISO(startDateTime);
       const duration = getDuration(session);
       return {
         label: name,
-        rawDate: startDateTime,
-        date: formatDateWithDay(startDate, timezone, ', '),
+        rawDate: start.toISOString(),
+        date: formatDateWithDay(start, timezone, ', '),
         time: formatTimeRange(start, duration, timezone),
-        duration: formatTimeDuration(startDate, duration),
+        duration: formatTimeDuration(start, duration),
         timezone: getNonLocationTimezone(start, timezone, true),
       };
     });

--- a/web/util/session.ts
+++ b/web/util/session.ts
@@ -36,13 +36,14 @@ export const sessionStart = (
 const getDuration = ({ session, duration, durationOverride }: ProgramSession) =>
   durationOverride ?? duration ?? session?.duration ?? 0;
 
-/* Given all Programs, finds the Programs that contain the Session (matching on _id).
+/* Given all Programs, finds the Programs that contain the Session (matching on sessionId === _id).
  * For each match, returns:
- * - the Program's associated Venue name (using the first entry in the Program's Venues array)
- * - the Session's date (based on the Session's start time)
- * - the Session's time range (accounting for any duration overrides)
- * - the Session's duration
- * - the Session's timezone
+ * - label: Program's associated Venue name (using the first entry in the Program's Venues array)
+ * - rawDate: the Session's date (based on the Session's start time)
+ * - date: rawDate, but formatted
+ * - time: the Session's time range, formatted (accounting for any duration overrides)
+ * - duration: the Session's duration, formatted
+ * - timezone: the Session's timezone, formatted
  */
 export const sessionTimingDetailsForMatchingPrograms = (
   programs: Program[],

--- a/web/util/session.ts
+++ b/web/util/session.ts
@@ -3,6 +3,7 @@ import type { Session } from '../types/Session';
 import type { Program, ProgramSession } from '../types/Program';
 import {
   formatDateWithDay,
+  formatTimeDuration,
   formatTimeRange,
   getNonLocationTimezone,
 } from './date';
@@ -40,6 +41,7 @@ const getDuration = ({ session, duration, durationOverride }: ProgramSession) =>
  * - the Program's associated Venue name (using the first entry in the Program's Venues array)
  * - the Session's date (based on the Session's start time)
  * - the Session's time range (accounting for any duration overrides)
+ * - the Session's duration
  * - the Session's timezone
  */
 export const sessionTimingDetailsForMatchingPrograms = (
@@ -63,10 +65,14 @@ export const sessionTimingDetailsForMatchingPrograms = (
       );
 
       const [{ name, timezone }] = venues;
+      const startDate = parseISO(startDateTime);
+      const duration = getDuration(session);
       return {
         label: name,
-        date: formatDateWithDay(parseISO(startDateTime), timezone, ', '),
-        time: formatTimeRange(start, getDuration(session), timezone),
+        rawDate: startDateTime,
+        date: formatDateWithDay(startDate, timezone, ', '),
+        time: formatTimeRange(start, duration, timezone),
+        duration: formatTimeDuration(startDate, duration),
         timezone: getNonLocationTimezone(start, timezone, true),
       };
     });

--- a/web/util/session.ts
+++ b/web/util/session.ts
@@ -46,15 +46,11 @@ export const sessionTimingDetailsForMatchingPrograms = (
   programs
     .map((program) => ({
       program,
-      sessionIndex: program.sessions.findIndex(
-        // TODO: would this be cleaner if we found the session instead of the index? (but commit first before refactoring)
-        (session) => session.session?._id === sessionId
-      ),
+      session: program.sessions.find((s) => s.session?._id === sessionId),
     }))
-    .filter((match) => match.sessionIndex !== -1)
-    .map(({ program: { sessions, startDateTime, venues }, sessionIndex }) => {
+    .filter((entry) => Boolean(entry.session))
+    .map(({ program: { sessions, startDateTime, venues }, session }) => {
       const [{ name, timezone }] = venues;
-      const session = sessions[sessionIndex];
       const start = sessionStart(
         startDateTime,
         session.session._id,

--- a/web/util/session.ts
+++ b/web/util/session.ts
@@ -7,7 +7,6 @@ import {
   formatTimeRange,
   getNonLocationTimezone,
 } from './date';
-import { format, formatInTimeZone } from 'date-fns-tz';
 
 const minutesFromProgramStart = (
   sessions: Pick<Session, 'duration'>[],

--- a/web/util/session.ts
+++ b/web/util/session.ts
@@ -1,6 +1,6 @@
 import { addMinutes, parseISO } from 'date-fns';
 import type { Session } from '../types/Session';
-import type { Program } from '../types/Program';
+import type { Program, ProgramSession } from '../types/Program';
 import {
   formatDateWithDay,
   formatTimeRange,
@@ -32,6 +32,9 @@ export const sessionStart = (
   return addMinutes(start, sessionStartOffset);
 };
 
+const getDuration = ({ session, duration, durationOverride }: ProgramSession) =>
+  durationOverride ?? duration ?? session?.duration ?? 0;
+
 /* Given all Programs, finds the Programs that contain the Session (matching on _id).
  * For each match, returns:
  * - the Program's associated Venue name (using the first entry in the Program's Venues array)
@@ -50,25 +53,20 @@ export const sessionTimingDetailsForMatchingPrograms = (
     }))
     .filter((entry) => Boolean(entry.session))
     .map(({ program: { sessions, startDateTime, venues }, session }) => {
-      const [{ name, timezone }] = venues;
       const start = sessionStart(
         startDateTime,
         session.session._id,
-        sessions.map(({ session, duration, durationOverride }) => ({
-          ...session,
-          duration: durationOverride ?? duration ?? session?.duration ?? 0,
+        sessions.map((programSession) => ({
+          ...programSession.session,
+          duration: getDuration(programSession),
         }))
       );
+
+      const [{ name, timezone }] = venues;
       return {
         label: name,
         date: formatDateWithDay(parseISO(startDateTime), timezone, ', '),
-        time: formatTimeRange(
-          start,
-          session.durationOverride ??
-            session.duration ??
-            session.session.duration,
-          timezone
-        ),
+        time: formatTimeRange(start, getDuration(session), timezone),
         timezone: getNonLocationTimezone(start, timezone, true),
       };
     });


### PR DESCRIPTION
# Session details: show dates & times for all Venues referencing Session

## Intent

List date and time for current Session for each Program/Venue combo which it appears in.
![image](https://user-images.githubusercontent.com/6001131/164727776-b1acc26c-aa19-448e-a02d-c76bd35eca66.png)

Solves [this](https://app.shortcut.com/sanity-io/story/17644/multiple-times-on-session-detail) Shortcut Story.

## Description

- Fetch all Venues from the main event
- Fetch Programs referencing to said Venues, in order to have Programs match the main event's Venue sort order
- For each Program referencing the current Session, render date and time info


Note that this PR [also fixes what I believe is a bug](https://github.com/sanity-io/structured-content-2022/commit/e3c25a0d25eb1ae8d11dd590b2604ba6c83fda0c) in _date.ts_#`formatTime`. This affects how the [Session times in the accordion under the "Programs: section heading"](https://structured-content-2022-web-git-session-details-multiple-times.sanity.build/program) render. This fix looks correct to me (and [the current production version](https://structuredcontent.live/program) does not, but please verify this.

(Note also that the code assumes that each Venue is only tied to a single Program, despite the Sanity model expressing the Venue->Program relationship as a one-to-many. Knut has previously mentioned somewhere on Slack that this will in in reality always be a one-to-one relationship.)

## Testing this PR

1. Open a Session that's referenced by at least one Program (which in turn is tied to a Venue referenced by the main event), e.g. [Cross-Functional Collaboration for Structured Content](https://structured-content-2022-web-git-session-details-multiple-times.sanity.build/program/cross-functional-collaboration-for-structured-content)
2. Verify that the dates & times for the event correlate with the data that's in Sanity for the event; make sure that both the displayed values and the `datetime` values of the respective tags are correct.
3. Open a Session that doesn't meet the criteria of 1) -- e.g. [Session not referenced by any Programs](https://structured-content-2022-web-git-session-details-multiple-times.sanity.build/program/not-referenced). Verify that it omits rendering any timing information without encountering any errors. 
