### PR TITLE
Fix footer focus indicator

### DIFF
--- a/web/components/Footer/Footer.module.css
+++ b/web/components/Footer/Footer.module.css
@@ -15,6 +15,13 @@
   display: inline-block; /* nicer focus outline */
 }
 
+.logoLink:focus-visible,
+.mailLink:focus-visible,
+.socialLink:focus-visible,
+.linksItemLink:focus-visible {
+  outline-color: var(--color-brand-white);
+}
+
 .mailLink {
   text-decoration: none;
   color: var(--color-ui-gray-600);


### PR DESCRIPTION
# Fix footer focus indicator

## Intent

Fix Shortcut story [Missing/invisible focus indicator in footer](https://app.shortcut.com/sanity-io/story/18962/missing-invisible-focus-indicator-in-footer), ensuring that the focus indicator is once again visible when navigating the footer via keyboard.

## Description

Regressed when the footer was changed to have black background.

Presently the PR just sets a blanket white outline color for all links in the footer. An alternative solution would be to use gray for the gray links. There's also a tradeoff of avoiding repetition (done here) vs splitting the outline ruleset up into separate copies so that all rules concerning `.socialLink` are grouped together etc.

## Testing this PR

1. Open https://structured-content-2022-web-git-fix-footer-focus-indicator.sanity.build/
2. Navigate down the page with `<Tab>` on the keyboard, until you get to the footer
3. Verify that the focus indicator is still visible when the "confinfo@sanity.io" link is focused, and similarly for the other links in the footer
