### PR TITLE
Remove '& Virtual' suffix added to main venue label

### DIFF
--- a/web/pages/program/[slug].tsx
+++ b/web/pages/program/[slug].tsx
@@ -54,7 +54,6 @@ const QUERY = groq`
     "programs": *[_id == "${mainEventId}"].venues[]-> {
       "program": *[_type == "program" && references(^._id)] { ${PROGRAM} }
     }["program"][],
-    "mainVenueName": (*[_id == "${mainEventId}"].venues[0]->.name)[0],
   }`;
 
 interface SessionRouteProps {
@@ -72,7 +71,6 @@ interface SessionRouteProps {
       }[];
     };
     programs: Program[];
-    mainVenueName: string;
   };
   slug: string;
 }
@@ -127,20 +125,11 @@ const SessionRoute = ({
     navItems,
     footer,
     programs,
-    mainVenueName,
   },
   slug,
 }: SessionRouteProps) => {
   const hasHighlightedSpeakers =
     speakers?.length && [1, 2].includes(speakers.length);
-  const matchingSessionsInPrograms = sessionTimingDetailsForMatchingPrograms(
-    programs,
-    _id
-  ).map(({ label, ...rest }) => ({
-    // Ad-hoc override for the SF venue, for this specific view only
-    label: label === mainVenueName ? `${label} & Virtual` : label,
-    ...rest,
-  }));
   return (
     <>
       <MetaTags
@@ -174,7 +163,7 @@ const SessionRoute = ({
                 <h1 className={programStyles.title}>{title}</h1>
 
                 <ul className={programStyles.venueTimes}>
-                  {matchingSessionsInPrograms.map(
+                  {sessionTimingDetailsForMatchingPrograms(programs, _id).map(
                     ({ label, time, timezone, rawDate, date, duration }) => (
                       <li className={programStyles.venueTime} key={label}>
                         <strong>{label}</strong>


### PR DESCRIPTION
# Remove '& Virtual' suffix added to main venue label

## Intent

Solves [this](https://app.shortcut.com/sanity-io/story/19169/session-detail-page-time-notation) Shortcut Story.

## Description

From the Story: 

> Solution - whichever is easier to implement:
> 1) Remove "& Virtual" from the label
> 2) Remove the Online display time

This PR opts for #1.

## Testing this PR

1. Visit a Session in the Preview Deploy of this PR that's scheduled for SF, e.g. [Cross-Functional Collaboration for Structured Content](https://structured-content-2022-web-git-feature-sc-19169session-42bd78.sanity.build/program/cross-functional-collaboration-for-structured-content-sf)
2. Verify that "& Online" is no longer suffixed to the "San Francisco label