### PR TITLE
move sold out boolean to ticket groups

### DIFF
--- a/studio/schemas/documents/ticket.ts
+++ b/studio/schemas/documents/ticket.ts
@@ -39,11 +39,6 @@ export default {
       type: "string",
     },
     {
-      name: "soldOut",
-      type: "boolean",
-      title: "Sold out?",
-    },
-    {
       name: "groups",
       title: "Ticket groups",
       type: "array",
@@ -57,6 +52,13 @@ export default {
               name: "name",
               title: "Ticket group name",
               type: "string",
+            },
+            {
+              name: "soldOut",
+              type: "boolean",
+              title: "Sold out?",
+              description:
+                "If true, this will override the availability of tickets, since they are sold out.",
             },
             {
               name: "priceAndAvailability",

--- a/web/components/TextBlock/Tickets/Tickets.module.css
+++ b/web/components/TextBlock/Tickets/Tickets.module.css
@@ -91,6 +91,7 @@
   margin: 0;
 }
 
+.soldOut,
 .currentPrice {
   font: var(--font-body-xl-medium);
   color: var(--color-brand-black);

--- a/web/components/TextBlock/Tickets/Tickets.module.css
+++ b/web/components/TextBlock/Tickets/Tickets.module.css
@@ -94,6 +94,7 @@
 .soldOut,
 .currentPrice {
   font: var(--font-body-xl-medium);
+  letter-spacing: var(--letter-spacing-body-xl);
   color: var(--color-brand-black);
 }
 

--- a/web/components/TextBlock/Tickets/Tickets.tsx
+++ b/web/components/TextBlock/Tickets/Tickets.tsx
@@ -71,34 +71,38 @@ const priceList = (ticket: Ticket) => (
       return (
         <li key={group.name} className={styles.group}>
           {group.name && <div className={styles.groupName}>{group.name}</div>}
-          <dl className={styles.priceGroup}>
-            {availabilityData(group)?.map(
-              ({ _key, label, price, isExpired, expires }) => (
-                <Fragment key={_key}>
-                  <dt
-                    className={clsx(
-                      styles.priceLabel,
-                      isExpired && styles.expired,
-                      !label && !expires && styles.visuallyHidden,
-                      currentTicket?._key === _key && styles.currentLabel
-                    )}
-                  >
-                    {label || 'Price'}
-                    {expires && expiryString(expires)}
-                  </dt>
-                  <dd
-                    className={clsx(
-                      styles.price,
-                      isExpired && styles.expired,
-                      currentTicket?._key === _key && styles.currentPrice
-                    )}
-                  >
-                    {price ? `$${price}` : 'Free'}
-                  </dd>
-                </Fragment>
-              )
-            )}
-          </dl>
+          {group.soldOut ? (
+            <div className={styles.soldOut}>Sold out</div>
+          ) : (
+            <dl className={styles.priceGroup}>
+              {availabilityData(group)?.map(
+                ({ _key, label, price, isExpired, expires }) => (
+                  <Fragment key={_key}>
+                    <dt
+                      className={clsx(
+                        styles.priceLabel,
+                        isExpired && styles.expired,
+                        !label && !expires && styles.visuallyHidden,
+                        currentTicket?._key === _key && styles.currentLabel
+                      )}
+                    >
+                      {label || 'Price'}
+                      {expires && expiryString(expires)}
+                    </dt>
+                    <dd
+                      className={clsx(
+                        styles.price,
+                        isExpired && styles.expired,
+                        currentTicket?._key === _key && styles.currentPrice
+                      )}
+                    >
+                      {price ? `$${price}` : 'Free'}
+                    </dd>
+                  </Fragment>
+                )
+              )}
+            </dl>
+          )}
         </li>
       );
     })}

--- a/web/types/Ticket.ts
+++ b/web/types/Ticket.ts
@@ -2,6 +2,7 @@ import { Section } from './Section';
 
 export type TicketGroup = {
   name: string;
+  soldOut?: boolean;
   priceAndAvailability: {
     _key: string;
     from: string;

--- a/web/util/queries.ts
+++ b/web/util/queries.ts
@@ -81,6 +81,7 @@ const TICKET = `
   description[]{ ${SIMPLE_BLOCK_CONTENT} },
   groups[]{
     name,
+    soldOut,
     priceAndAvailability[] { _key, from, label, price },    
   },
   included,


### PR DESCRIPTION
# Add "Sold out?"

## Intent

Make it possible to mark Oslo and London tickets as sold out. Resolves Shortcut story [Mark tickets as sold out in Tickets section](https://app.shortcut.com/sanity-io/story/20046/mark-tickets-as-sold-out-in-tickets-section).

## Description

Discussed in Slack: https://wja.slack.com/archives/C02UKELNTE0/p1652808693488369 (link valid for the Minus Slack).

This PR is a followup to https://github.com/sanity-io/structured-content-2022/pull/172 and includes both schema and app changes. Here, the sold out tickets are _not_ showed greyed-out (i.e. it intends to implement the first variant posted by Sindre in Slack, not the second).

## Testing this PR

1. Open https://structured-content-2022-studio-git-add-sold-out.sanity.build/desk/ticket;58dc88bb-2e29-4de1-8e91-d7755b0afc69 to edit a ticket type
2. Click a ticket group; verify that there is a "Sold out?" switch
3. Open https://structured-content-2022-web-git-add-sold-out.sanity.build/registration-info; verify that the in-person "Oslo and London" tickets are marked as "Sold out"
