### PR TITLE
Post-conference nav update

### DIFF
--- a/web/components/Nav/Nav.module.css
+++ b/web/components/Nav/Nav.module.css
@@ -12,6 +12,14 @@
   padding: 20px 0;
 }
 
+/* Keep .items centered even in the absence of a tickets button, without
+ * needing an empty div or changing the fact that .items left-align if they
+ * wrap to multiple lines
+ */
+.menuContents.noTickets::after {
+  content: '';
+}
+
 .logo {
   width: auto;
   height: 48px;

--- a/web/components/Nav/Nav.tsx
+++ b/web/components/Nav/Nav.tsx
@@ -12,7 +12,7 @@ import styles from './Nav.module.css';
 interface NavProps {
   onFrontPage?: boolean;
   currentPath: string;
-  ticketsUrl: string;
+  ticketsUrl?: string;
   items?: PrimaryNavItem[];
 }
 
@@ -48,7 +48,11 @@ export const Nav = ({
         </div>
         <div
           id={contentsId}
-          className={clsx(styles.menuContents, !menuOpened && styles.closed)}
+          className={clsx(
+            styles.menuContents,
+            !menuOpened && styles.closed,
+            !ticketsUrl && styles.noTickets
+          )}
         >
           <Link href="/">
             <a
@@ -68,15 +72,17 @@ export const Nav = ({
             </a>
           </Link>
           <ul className={clsx(styles.items, !menuOpened && styles.menuClosed)}>
-            <MenuItem
-              {...{ currentPath, closeMenu }}
-              href={ticketsUrl}
-              target="_blank"
-              rel="noreferrer"
-              className={styles.ticketItem}
-            >
-              Tickets
-            </MenuItem>
+            {ticketsUrl && (
+              <MenuItem
+                {...{ currentPath, closeMenu }}
+                href={ticketsUrl}
+                target="_blank"
+                rel="noreferrer"
+                className={styles.ticketItem}
+              >
+                Tickets
+              </MenuItem>
+            )}
 
             {items.map(
               ({ label, target: { external, internal, blank } }, index) => (
@@ -92,9 +98,11 @@ export const Nav = ({
               )
             )}
           </ul>
-          <div className={styles.ticketButton}>
-            <ButtonLink url={ticketsUrl} text="Tickets" openInNewTab={true} />
-          </div>
+          {ticketsUrl && (
+            <div className={styles.ticketButton}>
+              <ButtonLink url={ticketsUrl} text="Tickets" openInNewTab={true} />
+            </div>
+          )}
         </div>
       </GridWrapper>
     </nav>

--- a/web/components/NavBlock/NavBlock.tsx
+++ b/web/components/NavBlock/NavBlock.tsx
@@ -25,7 +25,7 @@ export const NavBlock = ({ ticketsUrl }: NavBlockProps) => {
         <FakeItem divider mobile />
         <FakeItem mobile />
 
-        <Item href="/sponsorship-information">Sponsorship</Item>
+        <FakeItem mobile tablet desktop />
 
         <FakeItem tablet desktop />
         <FakeItem divider mobile tablet desktop />
@@ -38,7 +38,7 @@ export const NavBlock = ({ ticketsUrl }: NavBlockProps) => {
         <FakeItem divider mobile />
         <FakeItem mobile />
 
-        <Item href="/registration-info">Registration</Item>
+        <FakeItem mobile tablet desktop />
 
         <FakeItem divider mobile tablet desktop />
 
@@ -48,9 +48,7 @@ export const NavBlock = ({ ticketsUrl }: NavBlockProps) => {
         <FakeItem mobile desktop />
         <FakeItem divider mobile />
 
-        <Item href={ticketsUrl} target="_blank" rel="noreferrer">
-          Tickets
-        </Item>
+        <FakeItem mobile tablet desktop />
 
         <FakeItem tablet desktop />
         <FakeItem mobile desktop />

--- a/web/components/NavBlock/NavBlock.tsx
+++ b/web/components/NavBlock/NavBlock.tsx
@@ -6,7 +6,7 @@ import Item from './Item';
 import styles from './NavBlock.module.css';
 
 interface NavBlockProps {
-  ticketsUrl: string;
+  ticketsUrl?: string;
 }
 
 export const NavBlock = ({ ticketsUrl }: NavBlockProps) => {
@@ -48,7 +48,13 @@ export const NavBlock = ({ ticketsUrl }: NavBlockProps) => {
         <FakeItem mobile desktop />
         <FakeItem divider mobile />
 
-        <FakeItem mobile tablet desktop />
+        {ticketsUrl ? (
+          <Item href={ticketsUrl} target="_blank" rel="noreferrer">
+            Tickets
+          </Item>
+        ) : (
+          <FakeItem mobile tablet desktop />
+        )}
 
         <FakeItem tablet desktop />
         <FakeItem mobile desktop />

--- a/web/pages/[[...slug]].tsx
+++ b/web/pages/[[...slug]].tsx
@@ -200,6 +200,11 @@ const Route = ({ data: initialData, slug, preview }: RouteProps) => {
     isFrontPage && styles.onFrontPage,
     isFrontPage && scrolledFarEnough && styles.scrolledDown
   );
+  /* This could be defined in the Sanity schema in the future, if this codebase
+   * is reused for other conferences. (Don't want to link to tickets page after
+   * the conference has happened.)
+   */
+  const showTicketsLink = false;
 
   return (
     <>
@@ -214,7 +219,7 @@ const Route = ({ data: initialData, slug, preview }: RouteProps) => {
         <Nav
           onFrontPage={isFrontPage}
           currentPath={currentPath}
-          ticketsUrl={ticketsUrl}
+          ticketsUrl={showTicketsLink ? ticketsUrl : undefined}
           items={navItems}
         />
       </header>
@@ -222,7 +227,7 @@ const Route = ({ data: initialData, slug, preview }: RouteProps) => {
         {slug === '/' ? (
           <GridWrapper>
             <ConferenceHeader name={mainEventName} description={description} />
-            <NavBlock ticketsUrl={ticketsUrl} />
+            <NavBlock ticketsUrl={showTicketsLink ? ticketsUrl : undefined} />
           </GridWrapper>
         ) : (
           <Hero {...hero} />


### PR DESCRIPTION
# Post-conference nav update

## Intent

Resolve the first two tasks in Shortcut story [Update conference home page](https://app.shortcut.com/sanity-io/story/20628/update-conference-home-page). Now that the conference is over, Sanity wants to remove some links from the navigation. This includes the Tickets "button" in the header bar and some links in the "nav block" on the front page.

## Description

The nav block is currently all hard-coded due to the lack of a generic design logic for how to lay out the links vs the filler boxes/shapes. Here I've replaced the obsolete links with fake boxes/shapes to maintain the overall look (although the distribution of links vs shapes may be slightly "lopsided").

Similarly, the tickets link in the header is currently hardcoded because it's displayed differently compared to the other menu links (it's a "button" in desktop) and the content model for the menu links doesn't have any way of communicating this special-casing.

For the tickets link I added a boolean to toggle on/off, as a small step made on the assumption that this code/repo will be reused further down the line to make other conference sites. (The boolean is currently hardcoded, but in the future it could be derived from the content in some fashion.)

The old Nav styles relied on `.ticketButton` to be present in order to keep the menu items centered. There are a few ways to solve that, I added the class `noTickets` in an attempt to solve it in (what I perceive to be) the best way (CSS `:has` is not well supported yet). More details in the [commit message](https://github.com/sanity-io/structured-content-2022/commit/a28396e886505bffc934812bdb524e21a1611526).

## Testing this PR

1. Open https://structured-content-2022-web-git-post-conference-nav-update.sanity.build/
2. With a relatively large window (not mobile-size), scroll down until a menu bar appears at the top of the screen; verify that there is no "Tickets" button on the right (before this PR is merged, you can compare and contrast with https://structuredcontent.live/)
3. Verify that the nav block (the grid of yellow boxes below the conference header) does not contain the links "Tickets", "Registration" or "Sponsorship"
4. Dismiss cookie dialog, shrink window until a Menu button appears at the bottom of the window (or use a mobile browser or emulation thereof such as Responsive Design Mode)
5. Click the "Menu" button and verify that the menu that appears does not contain "Tickets"